### PR TITLE
Add webhook server and plugin registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,25 @@ Cascadence aims to provide a flexible framework for orchestrating complex, multi
 - Built-in instrumentation and monitoring.
 
 This repository lays the groundwork for the Python package implementation.
+
+## Webhook Server Example
+
+Cascadence includes a lightweight FastAPI server for handling GitHub and
+Cal.com webhook events. Subclass `WebhookTask` to react to incoming events and
+start the server using `start_server`:
+
+```python
+from task_cascadence.plugins import WebhookTask
+from task_cascadence.webhook import start_server
+
+
+class PrintTask(WebhookTask):
+    def handle_event(self, source, event_type, payload):
+        print(f"{source} event {event_type}: {payload}")
+
+
+if __name__ == "__main__":
+    start_server()
+```
+
+Send GitHub events to `/webhook/github` and Cal.com events to `/webhook/calcom`.

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -9,9 +9,33 @@ class CronTask:
     pass
 
 
+webhook_task_registry = []
+
+
 class WebhookTask:
-    """Base class for tasks triggered via webhooks."""
-    pass
+    """Base class for tasks triggered via webhooks.
+
+    Subclasses are automatically registered so the webhook server can
+    invoke them when events arrive.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        webhook_task_registry.append(cls)
+
+    def handle_event(self, source: str, event_type: str, payload: dict) -> None:
+        """Handle an incoming webhook event.
+
+        Parameters
+        ----------
+        source:
+            The webhook source, e.g. ``"github"`` or ``"calcom"``.
+        event_type:
+            The event type string from the provider.
+        payload:
+            The JSON payload sent by the provider.
+        """
+        raise NotImplementedError()
 
 
 class ManualTrigger:

--- a/task_cascadence/webhook.py
+++ b/task_cascadence/webhook.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, Request
+import uvicorn
+
+from .plugins import webhook_task_registry
+
+app = FastAPI()
+
+
+@app.post("/webhook/github")
+async def github_webhook(request: Request):
+    payload = await request.json()
+    event_type = request.headers.get("X-GitHub-Event", "")
+    for task_cls in webhook_task_registry:
+        task = task_cls()
+        if hasattr(task, "handle_event"):
+            task.handle_event("github", event_type, payload)
+    return {"status": "received"}
+
+
+@app.post("/webhook/calcom")
+async def calcom_webhook(request: Request):
+    payload = await request.json()
+    event_type = request.headers.get("Cal-Event-Type", "")
+    for task_cls in webhook_task_registry:
+        task = task_cls()
+        if hasattr(task, "handle_event"):
+            task.handle_event("calcom", event_type, payload)
+    return {"status": "received"}
+
+
+def start_server(host: str = "0.0.0.0", port: int = 8000):
+    """Start the FastAPI webhook server."""
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- implement WebhookTask auto-registration
- add a FastAPI webhook server for GitHub and Cal.com
- document example webhook usage

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile ok'`

------
https://chatgpt.com/codex/tasks/task_e_6871cc5d0dd883269f8cc3047a9266ef