### PR TITLE
Add UME models and emission logic

### DIFF
--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -1,14 +1,39 @@
-"""Utilities for emitting TaskRun and TaskSpec to UME.
+"""Utilities for emitting TaskRun and TaskSpec to UME."""
 
-Refer to PRD section 'UME Integration'.
-"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from .models import TaskRun, TaskSpec
 
 
-def emit_task_spec(spec):
-    """Placeholder function for sending TaskSpec data to UME."""
-    pass
+def _queue_within_deadline(obj: Any, client: Any, max_delay: float = 0.2) -> threading.Thread:
+    """Queue *obj* to *client* in a background thread within ``max_delay`` seconds."""
+
+    def _send() -> None:
+        client.enqueue(obj)
+
+    thread = threading.Thread(target=_send, daemon=True)
+    start = time.monotonic()
+    thread.start()
+    thread.join(timeout=max_delay)
+    elapsed = time.monotonic() - start
+    if elapsed > max_delay:
+        raise RuntimeError(
+            f"Emission to client exceeded {max_delay}s deadline (took {elapsed:.3f}s)"
+        )
+    return thread
 
 
-def emit_task_run(run):
-    """Placeholder function for sending TaskRun data to UME."""
-    pass
+def emit_task_spec(spec: TaskSpec, client: Any) -> None:
+    """Emit ``TaskSpec`` information to ``client``."""
+
+    _queue_within_deadline(spec, client)
+
+
+def emit_task_run(run: TaskRun, client: Any) -> None:
+    """Emit ``TaskRun`` information to ``client``."""
+
+    _queue_within_deadline(run, client)

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class TaskSpec:
+    """Definition of a task to be executed."""
+
+    id: str
+    name: str
+    description: Optional[str] = None
+
+
+@dataclass
+class TaskRun:
+    """Metadata about a specific execution of a task."""
+
+    spec: TaskSpec
+    run_id: str
+    status: str
+    started_at: datetime
+    finished_at: datetime

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+import time
+
+
+from task_cascadence.ume import emit_task_run, emit_task_spec
+from task_cascadence.ume.models import TaskRun, TaskSpec
+
+
+class MockClient:
+    def __init__(self):
+        self.events = []
+
+    def enqueue(self, obj):
+        self.events.append((obj, time.monotonic()))
+
+
+def test_emit_task_run_within_deadline():
+    client = MockClient()
+    spec = TaskSpec(id="1", name="sample")
+    run = TaskRun(
+        spec=spec,
+        run_id="run1",
+        status="success",
+        started_at=datetime.now(),
+        finished_at=datetime.now(),
+    )
+
+    start = time.monotonic()
+    emit_task_run(run, client)
+    assert client.events
+    delay = client.events[0][1] - start
+    assert delay < 0.2
+
+
+def test_emit_task_spec_within_deadline():
+    client = MockClient()
+    spec = TaskSpec(id="2", name="other")
+    start = time.monotonic()
+    emit_task_spec(spec, client)
+    assert client.events
+    delay = client.events[0][1] - start
+    assert delay < 0.2


### PR DESCRIPTION
## Summary
- define dataclass stubs for `TaskSpec` and `TaskRun`
- implement emitter helper that queues objects within 200ms
- add unit tests for emission timing

## Testing
- `python3 -m ruff check task_cascadence tests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cc5d47988326820a05f774c49893