### PR TITLE
Add CronyxServer loader plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ Cascadence aims to provide a flexible framework for orchestrating complex, multi
 - Built-in instrumentation and monitoring.
 
 This repository lays the groundwork for the Python package implementation.
+
+## External Wrappers
+
+Wrappers written in other languages (for example Rust or Go) can integrate with
+Cascadence by exposing HTTP endpoints that follow the CronyxServer API. At
+minimum the wrapper should implement:
+
+* `GET /tasks` - returns a JSON array of available tasks.
+* `GET /tasks/<id>` - returns a JSON description of a task.
+
+The :class:`CronyxServerLoader` plugin can then load these definitions at
+runtime.

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -3,6 +3,8 @@
 See PRD section 'Plugin Architecture' for details.
 """
 
+from .cronyx_server import CronyxServerLoader
+
 
 class CronTask:
     """Base class for tasks triggered by cron schedules."""
@@ -17,3 +19,11 @@ class WebhookTask:
 class ManualTrigger:
     """Base class for tasks triggered manually."""
     pass
+
+
+__all__ = [
+    "CronTask",
+    "WebhookTask",
+    "ManualTrigger",
+    "CronyxServerLoader",
+]

--- a/task_cascadence/plugins/cronyx_server.py
+++ b/task_cascadence/plugins/cronyx_server.py
@@ -1,0 +1,22 @@
+import requests
+
+
+class CronyxServerLoader:
+    """Loader for tasks via CronyxServer's HTTP API."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip('/')
+
+    def _get(self, path: str):
+        url = f"{self.base_url}{path}"
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        return response.json()
+
+    def list_tasks(self):
+        """Return a list of available tasks."""
+        return self._get('/tasks')
+
+    def load_task(self, task_id: str):
+        """Return a single task definition by ID."""
+        return self._get(f'/tasks/{task_id}')


### PR DESCRIPTION
## Summary
- implement `CronyxServerLoader` to fetch tasks over HTTP
- expose loader via plugins package
- document required endpoints for external wrappers

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6871cc5dd2248326adbe261edefe9928