### PR TITLE
Add basic test suite and coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=task_cascadence --cov-report=term-missing

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure package root is on sys.path for test imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,5 @@
+from task_cascadence.cli import main
+
+
+def test_cli_main_returns_none():
+    assert main() is None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,39 @@
+import importlib
+
+from task_cascadence.plugins import CronTask
+
+
+def load_plugin(path: str):
+    module_path, class_name = path.split(":")
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls()
+
+
+class DummyCronTask(CronTask):
+    def __init__(self):
+        self.executed = False
+
+    def run(self):
+        self.executed = True
+        return "ran"
+
+
+def test_plugin_loading_and_execution(tmp_path, monkeypatch):
+    module_file = tmp_path / "myplugin.py"
+    module_file.write_text(
+        "from task_cascadence.plugins import CronTask\n"
+        "class Plugin(CronTask):\n"
+        "    def __init__(self):\n"
+        "        self.executed = False\n"
+        "    def run(self):\n"
+        "        self.executed = True\n"
+        "        return 'ok'\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    plugin = load_plugin("myplugin:Plugin")
+    result = plugin.run()
+
+    assert result == "ok"
+    assert plugin.executed

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+from task_cascadence.scheduler import BaseScheduler
+
+
+class DummyScheduler(BaseScheduler):
+    def __init__(self):
+        self.last_args = None
+        self.last_kwargs = None
+
+    def schedule_task(self, *args, **kwargs):
+        self.last_args = args
+        self.last_kwargs = kwargs
+        # Simulate scheduling by returning a scheduled time
+        tz = kwargs.get("timezone", ZoneInfo("UTC"))
+        return datetime.now(tz)
+
+
+def test_schedule_with_timezone():
+    sched = DummyScheduler()
+    tz = ZoneInfo("America/New_York")
+    scheduled_time = sched.schedule_task("task", timezone=tz)
+
+    assert isinstance(scheduled_time, datetime)
+    assert sched.last_kwargs["timezone"] == tz

--- a/tests/test_ume.py
+++ b/tests/test_ume.py
@@ -1,0 +1,23 @@
+import time
+
+from task_cascadence import ume
+
+
+def test_ume_emission_order(monkeypatch):
+    calls = []
+
+    def record_spec(spec):
+        calls.append(("spec", time.time()))
+
+    def record_run(run):
+        calls.append(("run", time.time()))
+
+    monkeypatch.setattr(ume, "emit_task_spec", record_spec)
+    monkeypatch.setattr(ume, "emit_task_run", record_run)
+
+    ume.emit_task_spec({"name": "test"})
+    time.sleep(0.01)
+    ume.emit_task_run({"id": 1})
+
+    types = [c[0] for c in calls]
+    assert types == ["spec", "run"]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,18 @@
+from task_cascadence.plugins import WebhookTask
+
+
+class DummyWebhookTask(WebhookTask):
+    def __init__(self):
+        self.events = []
+
+    def handle_event(self, event):
+        self.events.append(event)
+        return f"handled {event}"
+
+
+def test_webhook_routing():
+    task = DummyWebhookTask()
+    result = task.handle_event({"type": "ping"})
+
+    assert result == "handled {'type': 'ping'}"
+    assert task.events == [{"type": "ping"}]


### PR DESCRIPTION
## Summary
- add pytest.ini to configure coverage reports
- add unit tests for scheduler, webhook routing, plugin loading, UME emission and CLI

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cc6325f88326b12b15033b34b085