### PR TITLE
Implement basic metrics server

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -7,5 +7,6 @@ from . import scheduler  # noqa: F401
 from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
 from . import cli  # noqa: F401
+from . import metrics  # noqa: F401
 
-__all__ = ["scheduler", "plugins", "ume", "cli"]
+__all__ = ["scheduler", "plugins", "ume", "cli", "metrics"]

--- a/task_cascadence/metrics.py
+++ b/task_cascadence/metrics.py
@@ -1,0 +1,51 @@
+"""Prometheus metrics for Cascadence tasks."""
+
+from prometheus_client import Counter, Histogram, start_http_server
+import functools
+import time
+
+# Histogram tracking how long each task takes to run.
+TASK_LATENCY = Histogram(
+    "task_latency_seconds",
+    "Time spent executing tasks",
+    ["task_name"],
+)
+
+# Counters for successes and failures.
+TASK_SUCCESS = Counter(
+    "task_success_total",
+    "Total number of tasks completed successfully",
+    ["task_name"],
+)
+
+TASK_FAILURE = Counter(
+    "task_failure_total",
+    "Total number of tasks that raised an exception",
+    ["task_name"],
+)
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start an HTTP server to expose Prometheus metrics."""
+    start_http_server(port)
+
+
+def track_task(func):
+    """Decorator to record metrics for a task function."""
+    task_name = func.__name__
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.monotonic()
+        try:
+            result = func(*args, **kwargs)
+        except Exception:
+            TASK_FAILURE.labels(task_name).inc()
+            raise
+        else:
+            TASK_SUCCESS.labels(task_name).inc()
+            return result
+        finally:
+            duration = time.monotonic() - start_time
+            TASK_LATENCY.labels(task_name).observe(duration)
+
+    return wrapper

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -4,9 +4,13 @@ See PRD section 'Scheduling' for design details.
 """
 
 
-class BaseScheduler:
-    """Placeholder for scheduler integrations with APScheduler or Cronyx."""
+from ..metrics import track_task
 
-    def schedule_task(self, *args, **kwargs):
-        """Stub method for scheduling tasks."""
-        pass
+
+class BaseScheduler:
+    """Simplistic scheduler that runs tasks immediately and records metrics."""
+
+    def schedule_task(self, task_func, *args, **kwargs):
+        """Execute ``task_func`` and record execution metrics."""
+        wrapped = track_task(task_func)
+        return wrapped(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add Prometheus metrics server with counters and histogram
- hook scheduler to record task timing
- expose metrics module at package level

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871cc5eaa448326972081b836bd9b46