### PR TITLE
Implement task CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ Cascadence aims to provide a flexible framework for orchestrating complex, multi
 - Built-in instrumentation and monitoring.
 
 This repository lays the groundwork for the Python package implementation.
+
+## Command Line Usage
+
+After installing the package in an environment with ``typer`` available, the
+``task`` command becomes available.  It exposes several sub-commands:
+
+```bash
+$ task list       # show all registered tasks
+$ task run NAME   # execute a task
+$ task disable NAME  # disable a task
+```
+
+The repository ships with a single ``example`` task to demonstrate the
+mechanics.

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -1,9 +1,56 @@
 """Entry points for the command-line interface.
 
-See PRD section 'CLI Tools'.
+This CLI exposes a minimal ``task`` command with sub-commands to list, run and
+disable tasks as described in the PRD (FR-12).
 """
 
+from __future__ import annotations
 
-def main():
-    """Future CLI entry point."""
-    pass
+import typer
+
+from ..scheduler import default_scheduler
+from .. import plugins  # noqa: F401  # ensure tasks are registered
+
+
+app = typer.Typer(help="Interact with Cascadence tasks")
+
+
+@app.command("list")
+def list_tasks() -> None:
+    """List all registered tasks."""
+
+    for name, disabled in default_scheduler.list_tasks():
+        status = "disabled" if disabled else "enabled"
+        typer.echo(f"{name}\t{status}")
+
+
+@app.command("run")
+def run_task(name: str) -> None:
+    """Run ``NAME`` if it exists and is enabled."""
+
+    try:
+        default_scheduler.run_task(name)
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
+@app.command("disable")
+def disable_task(name: str) -> None:
+    """Disable ``NAME`` so it can no longer be executed."""
+
+    try:
+        default_scheduler.disable_task(name)
+        typer.echo(f"{name} disabled")
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
+def main() -> None:
+    """CLI entry point used by ``console_scripts`` or directly."""
+
+    app()
+
+
+__all__ = ["app", "main"]

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -1,19 +1,60 @@
-"""Plugin base classes for tasks.
+"""Plugin base classes and example tasks.
 
-See PRD section 'Plugin Architecture' for details.
+The project is designed to be extensible via plugins.  For demonstration
+purposes we provide a tiny plugin system and a single example task.  More
+complex projects could load plugins dynamically using entry points.
 """
 
+from typing import Dict
 
-class CronTask:
+from ..scheduler import default_scheduler
+
+
+class BaseTask:
+    """Base class for all tasks."""
+
+    name: str = "base"
+
+    def run(self):  # pragma: no cover - trivial demo function
+        """Run the task."""
+
+        print(f"running task {self.name}")
+
+
+class CronTask(BaseTask):
     """Base class for tasks triggered by cron schedules."""
     pass
 
 
-class WebhookTask:
+class WebhookTask(BaseTask):
     """Base class for tasks triggered via webhooks."""
     pass
 
 
-class ManualTrigger:
+class ManualTrigger(BaseTask):
     """Base class for tasks triggered manually."""
     pass
+
+
+# ---------------------------------------------------------------------------
+# Example tasks shipped with this repository.  Real deployments would load
+# plugins in a more dynamic fashion.
+
+class ExampleTask(CronTask):
+    """Very small task used in the examples."""
+
+    name = "example"
+
+    def run(self):  # pragma: no cover - illustrative
+        print("Example task executed")
+
+
+# ``registered_tasks`` is consumed by the scheduler during initialisation.
+registered_tasks: Dict[str, BaseTask] = {
+    ExampleTask.name: ExampleTask(),
+}
+
+# Register all tasks with the default scheduler on import so the CLI can access
+# them immediately.
+for _name, _task in registered_tasks.items():
+    default_scheduler.register_task(_name, _task)

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -1,12 +1,55 @@
-"""Wrappers for APScheduler/Cronyx.
+"""Simple in-memory scheduler.
 
-See PRD section 'Scheduling' for design details.
+This module provides a minimal scheduler implementation that mimics the
+behaviour described in the PRD.  It is intentionally lightweight so the CLI
+can interact with tasks without pulling in heavy dependencies like
+APScheduler.
 """
 
 
-class BaseScheduler:
-    """Placeholder for scheduler integrations with APScheduler or Cronyx."""
+from typing import Any, Dict, Iterable, Tuple
 
-    def schedule_task(self, *args, **kwargs):
-        """Stub method for scheduling tasks."""
-        pass
+
+class BaseScheduler:
+    """Very small task scheduler used by the CLI."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, Dict[str, Any]] = {}
+
+    def register_task(self, name: str, task: Any) -> None:
+        """Register a task object under ``name``."""
+
+        self._tasks[name] = {"task": task, "disabled": False}
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    def list_tasks(self) -> Iterable[Tuple[str, bool]]:
+        """Return an iterable of ``(name, disabled)`` tuples."""
+
+        for name, info in self._tasks.items():
+            yield name, info["disabled"]
+
+    def run_task(self, name: str) -> Any:
+        """Run a task by name if it exists and is enabled."""
+
+        info = self._tasks.get(name)
+        if not info:
+            raise ValueError(f"Unknown task: {name}")
+        if info["disabled"]:
+            raise ValueError(f"Task '{name}' is disabled")
+        task = info["task"]
+        if hasattr(task, "run"):
+            return task.run()
+        raise AttributeError(f"Task '{name}' has no run() method")
+
+    def disable_task(self, name: str) -> None:
+        """Disable a registered task."""
+
+        if name not in self._tasks:
+            raise ValueError(f"Unknown task: {name}")
+        self._tasks[name]["disabled"] = True
+
+
+# ``default_scheduler`` is used by the CLI.  Tasks from
+# :mod:`task_cascadence.plugins` will register themselves with it.
+default_scheduler = BaseScheduler()


### PR DESCRIPTION
## Summary
- add a lightweight scheduler with task registration
- provide basic plugin system with an example task
- implement `task` CLI using Typer to list, run and disable tasks
- document CLI usage in the README

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871cc5e85648326b787aa73519710a9