### PR TITLE
Implement APScheduler CronScheduler

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -6,7 +6,9 @@ See PRD section 'Plugin Architecture' for details.
 
 class CronTask:
     """Base class for tasks triggered by cron schedules."""
-    pass
+    def run(self):
+        """Execute the task. Subclasses must override this method."""
+        raise NotImplementedError
 
 
 class WebhookTask:

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -3,6 +3,13 @@
 See PRD section 'Scheduling' for design details.
 """
 
+from pathlib import Path
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+import pytz
+import yaml
+
 
 class BaseScheduler:
     """Placeholder for scheduler integrations with APScheduler or Cronyx."""
@@ -10,3 +17,69 @@ class BaseScheduler:
     def schedule_task(self, *args, **kwargs):
         """Stub method for scheduling tasks."""
         pass
+
+
+class CronScheduler(BaseScheduler):
+    """APScheduler-based scheduler using cron triggers.
+
+    Provides timezone-aware scheduling of tasks.
+    """
+
+    def __init__(self, timezone="UTC", storage_path="schedules.yml"):
+        self._CronTrigger = CronTrigger
+        self._yaml = yaml
+        tz = pytz.timezone(timezone) if isinstance(timezone, str) else timezone
+        self.scheduler = BackgroundScheduler(timezone=tz)
+        self.storage_path = Path(storage_path)
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self.schedules = self._load_schedules()
+
+    def _load_schedules(self):
+        if self.storage_path.exists():
+            with open(self.storage_path, "r") as fh:
+                data = self._yaml.safe_load(fh) or {}
+                if isinstance(data, dict):
+                    return data
+        return {}
+
+    def _save_schedules(self):
+        with open(self.storage_path, "w") as fh:
+            self._yaml.safe_dump(self.schedules, fh)
+
+    def _wrap_task(self, task):
+        def runner():
+            from ..ume import emit_task_run
+
+            try:
+                result = task.run()
+                emit_task_run(
+                    {"task": task.__class__.__name__, "result": result}
+                )
+            except Exception as exc:  # pragma: no cover - passthrough
+                emit_task_run(
+                    {"task": task.__class__.__name__, "error": str(exc)}
+                )
+                raise
+
+        return runner
+
+    def register_task(self, task, cron_expression):
+        job_id = task.__class__.__name__
+        self.schedules[job_id] = cron_expression
+        self._save_schedules()
+
+        trigger = self._CronTrigger.from_crontab(
+            cron_expression, timezone=self.scheduler.timezone
+        )
+        self.scheduler.add_job(
+            self._wrap_task(task), trigger=trigger, id=job_id
+        )
+
+    def start(self):
+        self.scheduler.start()
+
+    def shutdown(self, wait=True):
+        self.scheduler.shutdown(wait=wait)
+
+    def list_jobs(self):
+        return self.scheduler.get_jobs()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,48 @@
+import yaml
+from task_cascadence.scheduler import CronScheduler
+from task_cascadence.plugins import CronTask
+
+
+class DummyTask(CronTask):
+    def __init__(self):
+        self.count = 0
+
+    def run(self):
+        self.count += 1
+        return self.count
+
+
+def test_timezone_awareness(tmp_path):
+    storage = tmp_path / "sched.yml"
+    sched = CronScheduler(timezone="US/Pacific", storage_path=storage)
+    task = DummyTask()
+    sched.register_task(task, "0 12 * * *")
+    job = sched.scheduler.get_job("DummyTask")
+    assert str(job.trigger.timezone) == "US/Pacific"
+
+
+def test_schedule_persistence(tmp_path):
+    storage = tmp_path / "sched.yml"
+    sched = CronScheduler(timezone="UTC", storage_path=storage)
+    task = DummyTask()
+    sched.register_task(task, "*/5 * * * *")
+    data = yaml.safe_load(storage.read_text())
+    assert data["DummyTask"] == "*/5 * * * *"
+
+
+def test_run_emits_result(monkeypatch, tmp_path):
+    emitted = {}
+
+    def fake_emit(data):
+        emitted.update(data)
+
+    from task_cascadence import ume
+
+    monkeypatch.setattr(ume, "emit_task_run", fake_emit)
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+    sched.register_task(task, "*/1 * * * *")
+    job = sched.scheduler.get_job("DummyTask")
+    job.func()
+    assert emitted["task"] == "DummyTask"
+    assert emitted["result"] == 1


### PR DESCRIPTION
## Summary
- implement `CronScheduler` for timezone-aware cron scheduling
- add `run` requirement in `CronTask`
- emit run results to UME
- store schedules in YAML files
- test scheduler timezone awareness and YAML persistence

## Testing
- `flake8`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cc5d38448326ab3686554d328608