### PR TITLE
Instantiate default scheduler for CLI/plugins

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -127,3 +127,19 @@ class CronScheduler(BaseScheduler):
     def list_jobs(self):
         return self.scheduler.get_jobs()
 
+
+# ---------------------------------------------------------------------------
+# Default scheduler instance
+
+# ``default_scheduler`` provides a ready-to-use scheduler for the CLI and
+# plugins.  It keeps the import lightweight by using :class:`BaseScheduler` so
+# tests and simple invocations do not require APScheduler to be fully
+# configured.
+default_scheduler = BaseScheduler()
+
+__all__ = [
+    "BaseScheduler",
+    "CronScheduler",
+    "default_scheduler",
+]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
-from task_cascadence.cli import main
+from typer.testing import CliRunner
+from task_cascadence.cli import app
 
 
-def test_cli_main_returns_none():
-    assert main() is None
+def test_cli_list_runs():
+    runner = CliRunner()
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,2 +1,16 @@
+from task_cascadence.scheduler import BaseScheduler, default_scheduler
+
+
 def test_sanity():
     assert 1 + 1 == 2
+
+
+def test_default_scheduler_available():
+    assert isinstance(default_scheduler, BaseScheduler)
+
+
+def test_example_task_registered():
+    from task_cascadence import plugins  # noqa: F401 - trigger side effects
+
+    tasks = [name for name, _ in default_scheduler.list_tasks()]
+    assert "example" in tasks


### PR DESCRIPTION
## Summary
- provide a default scheduler instance
- export `default_scheduler` via `__all__`
- run CLI using Typer's testing utilities
- validate that the default scheduler exists and that example tasks are registered

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d394155483268a4216a8f2b24cee