### PR TITLE
Add configurable gRPC and NATS transport support

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -8,5 +8,6 @@ from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
 from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
+from . import transport  # noqa: F401
 
-__all__ = ["scheduler", "plugins", "ume", "cli", "metrics"]
+__all__ = ["scheduler", "plugins", "ume", "cli", "metrics", "transport"]

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -6,7 +6,6 @@ disable tasks as described in the PRD (FR-12).
 
 from __future__ import annotations
 
-import click
 import typer
 
 from ..scheduler import default_scheduler

--- a/task_cascadence/transport.py
+++ b/task_cascadence/transport.py
@@ -1,0 +1,54 @@
+"""Transport clients for delivering events to external services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class BaseTransport:
+    """Abstract transport client interface."""
+
+    def enqueue(self, obj: Any, timeout: float = 0.2) -> None:
+        """Send *obj* using the transport within ``timeout`` seconds."""
+        raise NotImplementedError
+
+
+class GrpcClient(BaseTransport):
+    """gRPC transport client using a provided stub."""
+
+    def __init__(self, stub: Any, method: str = "Send") -> None:
+        self._stub = stub
+        self._method = method
+
+    def enqueue(self, obj: Any, timeout: float = 0.2) -> None:  # pragma: no cover - simple delegation
+        rpc = getattr(self._stub, self._method)
+        rpc(obj, timeout=timeout)
+
+
+class NatsClient(BaseTransport):
+    """NATS transport client using a connection object."""
+
+    def __init__(self, connection: Any, subject: str = "events") -> None:
+        self._connection = connection
+        self._subject = subject
+
+    def enqueue(self, obj: Any, timeout: float = 0.2) -> None:  # pragma: no cover - simple delegation
+        self._connection.publish(self._subject, obj)
+        self._connection.flush(timeout=timeout)
+
+
+def get_client(transport: str, **kwargs: Any) -> BaseTransport:
+    """Return a transport client for ``transport``."""
+    if transport == "grpc":
+        return GrpcClient(**kwargs)
+    if transport == "nats":
+        return NatsClient(**kwargs)
+    raise ValueError(f"Unknown transport type: {transport}")
+
+
+__all__ = [
+    "BaseTransport",
+    "GrpcClient",
+    "NatsClient",
+    "get_client",
+]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,71 @@
+import time
+import pytest
+
+from task_cascadence.transport import GrpcClient, NatsClient
+from task_cascadence.ume import emit_task_spec
+from task_cascadence.ume.models import TaskSpec
+
+
+class Stub:
+    def __init__(self):
+        self.timeout = None
+        self.received = None
+
+    def Send(self, msg, timeout=None):
+        self.timeout = timeout
+        self.received = msg
+
+
+class SlowStub:
+    def Send(self, msg, timeout=None):
+        time.sleep(0.3)
+
+
+class FakeConn:
+    def __init__(self):
+        self.published = []
+        self.flushed = None
+
+    def publish(self, subject, msg):
+        self.published.append((subject, msg))
+
+    def flush(self, timeout=0):
+        self.flushed = timeout
+
+
+class SlowConn(FakeConn):
+    def flush(self, timeout=0):
+        time.sleep(0.3)
+        super().flush(timeout)
+
+
+def test_grpc_client_passes_timeout():
+    stub = Stub()
+    client = GrpcClient(stub)
+    client.enqueue("data", timeout=0.1)
+    assert stub.timeout == 0.1
+    assert stub.received == "data"
+
+
+def test_grpc_deadline_exceeded():
+    stub = SlowStub()
+    client = GrpcClient(stub)
+    spec = TaskSpec(id="1", name="demo")
+    with pytest.raises(RuntimeError):
+        emit_task_spec(spec, client=client)
+
+
+def test_nats_client_passes_timeout():
+    conn = FakeConn()
+    client = NatsClient(conn, subject="demo")
+    client.enqueue("msg", timeout=0.15)
+    assert conn.flushed == 0.15
+    assert conn.published == [("demo", "msg")]
+
+
+def test_nats_deadline_exceeded():
+    conn = SlowConn()
+    client = NatsClient(conn)
+    spec = TaskSpec(id="2", name="nats")
+    with pytest.raises(RuntimeError):
+        emit_task_spec(spec, client=client)


### PR DESCRIPTION
## Summary
- implement `GrpcClient` and `NatsClient` in new `transport` module
- allow configuring a default transport client in `ume`
- export transport package at project root
- adjust CLI imports
- add unit tests for transport clients and deadline handling

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871daec68e8832682d277cbc61d75e3