### PR TITLE
Integrate CronyxServer task loading

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -9,4 +9,34 @@ from . import ume  # noqa: F401
 from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 
+
+def _load_remote_tasks() -> None:
+    """Load tasks from a CronyxServer if ``CRONYX_BASE_URL`` is set."""
+
+    import os
+    from importlib import import_module
+
+    base_url = os.getenv("CRONYX_BASE_URL")
+    if not base_url:
+        return
+
+    from .plugins.cronyx_server import CronyxServerLoader
+
+    loader = CronyxServerLoader(base_url)
+
+    for entry in loader.list_tasks():
+        task_id = entry["id"] if isinstance(entry, dict) else entry
+        spec = loader.load_task(task_id)
+        path = spec.get("path") or spec.get("module")
+        if not path:
+            continue
+        module_name, class_name = path.split(":", 1)
+        module = import_module(module_name)
+        cls = getattr(module, class_name)
+        name = spec.get("name", getattr(cls, "name", task_id))
+        scheduler.default_scheduler.register_task(name, cls())
+
+
+_load_remote_tasks()
+
 __all__ = ["scheduler", "plugins", "ume", "cli", "metrics"]

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -6,7 +6,7 @@ disable tasks as described in the PRD (FR-12).
 
 from __future__ import annotations
 
-import click
+import click  # noqa: F401
 import typer
 
 from ..scheduler import default_scheduler

--- a/tests/test_cronyx_integration.py
+++ b/tests/test_cronyx_integration.py
@@ -1,0 +1,45 @@
+import importlib
+from textwrap import dedent
+
+def test_tasks_loaded_from_cronyx(monkeypatch, tmp_path):
+    # create a plugin to be loaded dynamically
+    plugin_file = tmp_path / "remote_mod.py"
+    plugin_file.write_text(
+        dedent(
+            """
+            from task_cascadence.plugins import CronTask
+
+            class RemoteTask(CronTask):
+                name = "remote"
+
+                def run(self):
+                    return "ok"
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # fake loader that returns our plugin path
+    class DummyLoader:
+        def __init__(self, base_url: str) -> None:
+            self.base_url = base_url
+
+        def list_tasks(self):
+            return [{"id": "remote"}]
+
+        def load_task(self, task_id: str):
+            assert task_id == "remote"
+            return {"id": "remote", "path": "remote_mod:RemoteTask"}
+
+    monkeypatch.setenv("CRONYX_BASE_URL", "http://server")
+    monkeypatch.setattr(
+        "task_cascadence.plugins.cronyx_server.CronyxServerLoader",
+        DummyLoader,
+    )
+
+    import task_cascadence
+
+    importlib.reload(task_cascadence)
+
+    tasks = [name for name, _ in task_cascadence.scheduler.default_scheduler.list_tasks()]
+    assert "remote" in tasks


### PR DESCRIPTION
## Summary
- fetch remote tasks from CronyxServer when `CRONYX_BASE_URL` is set
- ignore Ruff F401 for the `click` import
- add regression test for loading tasks from CronyxServer

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871daebb6f48326a686b570a1fda1b3