### PR TITLE
Add n8n export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This
 allows scheduled tasks to survive process restarts.
 
+## n8n Export
+
+Tasks registered with Cascadence can be exported as an n8n workflow using the
+``export-n8n`` command:
+
+```bash
+$ task export-n8n workflow.json
+```
+
+The resulting ``workflow.json`` can be imported into your n8n instance by
+selecting **Import from File** in the workflow menu and choosing the generated
+file.
+

--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -10,5 +10,7 @@ from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 
+plugins.load_cronyx_tasks()
+
 
 __all__ = ["scheduler", "plugins", "ume", "cli", "metrics", "temporal"]

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -12,6 +12,7 @@ import typer
 
 from ..scheduler import default_scheduler
 from .. import plugins  # noqa: F401  # ensure tasks are registered
+from ..n8n import export_workflow
 
 
 app = typer.Typer(help="Interact with Cascadence tasks")
@@ -49,6 +50,18 @@ def disable_task(name: str) -> None:
         raise typer.Exit(code=1)
 
 
+@app.command("export-n8n")
+def export_n8n(path: str) -> None:
+    """Export registered tasks as an n8n workflow to ``PATH``."""
+
+    try:
+        export_workflow(default_scheduler, path)
+        typer.echo(f"workflow written to {path}")
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
 
@@ -63,4 +76,4 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main"]
+__all__ = ["app", "main", "export_n8n"]

--- a/task_cascadence/n8n.py
+++ b/task_cascadence/n8n.py
@@ -1,0 +1,54 @@
+"""Utilities for exporting tasks to n8n workflows."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+from .scheduler import BaseScheduler
+
+
+NODE_DISTANCE = 250
+
+
+def to_workflow(scheduler: BaseScheduler) -> Dict[str, Any]:
+    """Return a dict representing a minimal n8n workflow."""
+    nodes = [
+        {
+            "id": "1",
+            "name": "Start",
+            "type": "n8n-nodes-base.start",
+            "typeVersion": 1,
+            "position": [0, 0],
+            "parameters": {},
+        }
+    ]
+    connections: Dict[str, Any] = {}
+    previous = "Start"
+    node_id = 2
+    y = 0
+    for name, _disabled in scheduler.list_tasks():
+        nodes.append(
+            {
+                "id": str(node_id),
+                "name": name,
+                "type": "n8n-nodes-base.code",
+                "typeVersion": 1,
+                "position": [NODE_DISTANCE * (node_id - 1), y],
+                "parameters": {"jsCode": f"// run {name}"},
+            }
+        )
+        connections.setdefault(previous, {"main": [[]]})
+        connections[previous]["main"][0].append(
+            {"node": name, "type": "main", "index": 0}
+        )
+        previous = name
+        node_id += 1
+    return {"name": "Cascadence Export", "nodes": nodes, "connections": connections}
+
+
+def export_workflow(scheduler: BaseScheduler, path: str) -> None:
+    """Write workflow JSON for ``scheduler`` to ``path``."""
+    wf = to_workflow(scheduler)
+    with open(path, "w") as fh:
+        json.dump(wf, fh, indent=2)

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -100,6 +100,7 @@ class CronScheduler(BaseScheduler):
         timezone: str | pytz.tzinfo.BaseTzInfo = "UTC",
         storage_path: str = "schedules.yml",
         temporal: Optional[TemporalBackend] = None,
+        tasks: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(temporal=temporal)
 

--- a/tests/test_n8n.py
+++ b/tests/test_n8n.py
@@ -1,0 +1,21 @@
+import json
+from typer.testing import CliRunner
+
+from task_cascadence.cli import app
+from task_cascadence.scheduler import default_scheduler
+from task_cascadence.n8n import to_workflow
+
+
+def test_to_workflow_produces_nodes():
+    wf = to_workflow(default_scheduler)
+    assert "nodes" in wf
+    assert any(n["name"] == "example" for n in wf["nodes"])
+
+
+def test_cli_export_n8n(tmp_path):
+    out = tmp_path / "flow.json"
+    runner = CliRunner()
+    result = runner.invoke(app, ["export-n8n", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert "nodes" in data


### PR DESCRIPTION
## Summary
- export tasks to n8n workflow JSON
- expose `export-n8n` CLI command
- load plugins from Cronyx server at runtime
- document n8n export usage
- add tests for n8n export

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687307ab17cc8326aa2916a0a83148c5