### PR TITLE
Add metrics server doc and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This
 allows scheduled tasks to survive process restarts.
 
+
+## Metrics
+
+Use ``start_metrics_server`` to expose Prometheus metrics for tasks. Run it at application startup specifying a port:
+
+```python
+from task_cascadence.metrics import start_metrics_server
+
+start_metrics_server(port=9000)
+```
+
+Metrics like ``task_latency_seconds`` and ``task_success_total`` will then be available from ``http://localhost:9000/metrics``.

--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -10,5 +10,7 @@ from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 
+plugins.maybe_load_cronyx_tasks()
+
 
 __all__ = ["scheduler", "plugins", "ume", "cli", "metrics", "temporal"]

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -6,6 +6,8 @@ can interact with tasks without pulling in heavy dependencies like
 APScheduler.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -14,7 +16,10 @@ import pytz
 import yaml
 
 
-from typing import Any, Dict, Iterable, Tuple, Optional
+from typing import Any, Dict, Iterable, Tuple, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..plugins import BaseTask
 
 from ..temporal import TemporalBackend
 
@@ -100,7 +105,9 @@ class CronScheduler(BaseScheduler):
         timezone: str | pytz.tzinfo.BaseTzInfo = "UTC",
         storage_path: str = "schedules.yml",
         temporal: Optional[TemporalBackend] = None,
-    ):
+        *,
+        tasks: Optional[Dict[str, "BaseTask"]] = None,
+    ) -> None:
         super().__init__(temporal=temporal)
 
         self._CronTrigger = CronTrigger

--- a/task_cascadence/temporal.py
+++ b/task_cascadence/temporal.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Optional
 import asyncio
 
-from temporalio.client import Client
-from temporalio.worker import Replayer
+try:  # pragma: no cover - optional dependency
+    from temporalio.client import Client
+    from temporalio.worker import Replayer
+except Exception:  # pragma: no cover - library not installed
+    Client = None  # type: ignore
+    Replayer = None  # type: ignore
 
 
 class TemporalBackend:
@@ -17,6 +21,8 @@ class TemporalBackend:
         self._client: Optional[Client] = None
 
     async def connect(self) -> Client:
+        if Client is None:
+            raise RuntimeError("temporalio is not installed")
         if not self._client:
             self._client = await Client.connect(self.server)
         return self._client
@@ -31,4 +37,6 @@ class TemporalBackend:
 
     def replay(self, history_path: str) -> None:
         """Replay a workflow history from ``history_path`` for debugging."""
+        if Replayer is None:
+            raise RuntimeError("temporalio is not installed")
         Replayer().replay(history_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,32 @@
+import socket
+import time
+
+import httpx
+from task_cascadence.metrics import start_metrics_server
+
+
+def _get_free_port():
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def test_metrics_endpoint_exposes_counters():
+    port = _get_free_port()
+    start_metrics_server(port)
+    for _ in range(10):
+        try:
+            resp = httpx.get(f"http://localhost:{port}/metrics")
+            if resp.status_code == 200:
+                break
+        except Exception:
+            time.sleep(0.05)
+    else:
+        raise AssertionError("metrics endpoint not reachable")
+
+    body = resp.text
+    assert "task_latency_seconds" in body
+    assert "task_success_total" in body
+    assert "task_failure_total" in body


### PR DESCRIPTION
## Summary
- document `start_metrics_server` in README
- test that `/metrics` endpoint exposes counters
- handle optional Temporal and Cronyx dependencies gracefully

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687307aab58083269aff43362689a8cc