### PR TITLE
Add temporalio and httpx dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "pytz",
     "pyyaml",
     "requests",
+    "temporalio",
+    "httpx",
 ]
 
 [project.scripts]

--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -5,13 +5,12 @@ This package provides task orchestration utilities described in the PRD.
 
 from . import scheduler  # noqa: F401
 from . import plugins  # noqa: F401
-plugins.initialize()
-
 from . import ume  # noqa: F401
 from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 
+plugins.initialize()
 plugins.load_cronyx_tasks()
 
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -7,10 +7,9 @@ complex projects could load plugins dynamically using entry points.
 
 import importlib
 import os
+import sys
 from importlib import metadata
 from typing import Dict
-import os
-import importlib
 
 
 from ..scheduler import default_scheduler

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -17,7 +17,7 @@ import yaml
 from typing import Any, Dict, Iterable, Tuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from ..plugins import BaseTask
+    from ..plugins import BaseTask  # noqa: F401
 
 from ..temporal import TemporalBackend
 
@@ -102,7 +102,6 @@ class CronScheduler(BaseScheduler):
         self,
         timezone: str | pytz.tzinfo.BaseTzInfo = "UTC",
         storage_path: str = "schedules.yml",
-        tasks: Optional[Dict[str, Any]] = None,
         temporal: Optional[TemporalBackend] = None,
         tasks: Optional[Dict[str, Any]] = None,
 


### PR DESCRIPTION
## Summary
- add `temporalio` and `httpx` deps
- fix scheduler constructor
- import `sys` in plugin module
- reorder imports for `__init__`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a69bfb483268ffd2ec189a015a5