### PR TITLE
Fix duplicate parameter in CronScheduler

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -7,10 +7,9 @@ complex projects could load plugins dynamically using entry points.
 
 import importlib
 import os
+import sys
 from importlib import metadata
 from typing import Dict
-import os
-import importlib
 
 
 from ..scheduler import default_scheduler

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -100,12 +100,10 @@ class CronScheduler(BaseScheduler):
 
     def __init__(
         self,
-        timezone: str | pytz.tzinfo.BaseTzInfo = "UTC",
-        storage_path: str = "schedules.yml",
-        tasks: Optional[Dict[str, Any]] = None,
-        temporal: Optional[TemporalBackend] = None,
-        tasks: Optional[Dict[str, Any]] = None,
-
+        timezone="UTC",
+        storage_path="schedules.yml",
+        tasks=None,
+        temporal=None,
     ):
         super().__init__(temporal=temporal)
 


### PR DESCRIPTION
## Summary
- remove duplicate `tasks` parameter in `CronScheduler.__init__`
- set default args according to design
- fix missing `sys` import in plugins

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a6d16708326a47687621b52e61c