### PR TITLE
Refactor plugin initialization

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -5,14 +5,20 @@ This package provides task orchestration utilities described in the PRD.
 
 from . import scheduler  # noqa: F401
 from . import plugins  # noqa: F401
-plugins.initialize()
-
 from . import ume  # noqa: F401
 from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 
-plugins.load_cronyx_tasks()
+
+def _init_plugins() -> None:
+    """Initialise and load plugins."""
+
+    plugins.initialize()
+    plugins.load_cronyx_tasks()
+
+
+_init_plugins()
 
 
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -7,10 +7,9 @@ complex projects could load plugins dynamically using entry points.
 
 import importlib
 import os
+import sys
 from importlib import metadata
 from typing import Dict
-import os
-import importlib
 
 
 from ..scheduler import default_scheduler
@@ -141,4 +140,3 @@ def load_cronyx_tasks() -> None:
     except Exception:  # pragma: no cover - best effort loading
         pass
 
-load_cronyx_tasks()

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -17,7 +17,7 @@ import yaml
 from typing import Any, Dict, Iterable, Tuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from ..plugins import BaseTask
+    from ..plugins import BaseTask  # noqa: F401
 
 from ..temporal import TemporalBackend
 
@@ -104,7 +104,6 @@ class CronScheduler(BaseScheduler):
         storage_path: str = "schedules.yml",
         tasks: Optional[Dict[str, Any]] = None,
         temporal: Optional[TemporalBackend] = None,
-        tasks: Optional[Dict[str, Any]] = None,
 
     ):
         super().__init__(temporal=temporal)


### PR DESCRIPTION
## Summary
- move imports in `task_cascadence.__init__` to the top
- initialise plugins in a protected function
- fix duplicate argument in scheduler
- fix imports in plugins module

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68732a6a8cc88326acc89f744b75e39d