### PR TITLE
Use CronScheduler as default scheduler

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -161,7 +161,26 @@ class CronScheduler(BaseScheduler):
 
         return runner
 
-    def register_task(self, task, cron_expression):
+    def register_task(self, arg1, arg2):
+        """Register a task with optional scheduling.
+
+        This method supports two calling styles for backwards
+        compatibility with :class:`BaseScheduler`:
+
+        ``register_task(name, task)``
+            Register ``task`` under ``name`` without scheduling.
+
+        ``register_task(task, cron_expression)``
+            Register ``task`` and schedule it using ``cron_expression``.
+        """
+
+        if isinstance(arg1, str):
+            # Called with ``name`` and ``task``
+            name, task = arg1, arg2
+            super().register_task(name, task)
+            return
+
+        task, cron_expression = arg1, arg2
         job_id = task.__class__.__name__
         super().register_task(job_id, task)
         self.schedules[job_id] = cron_expression
@@ -188,6 +207,6 @@ class CronScheduler(BaseScheduler):
 # A default scheduler instance used by the CLI and plugin registration. Tests
 # expect this object to exist at module scope.
 
-default_scheduler = BaseScheduler()
+default_scheduler = CronScheduler()
 
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
-from task_cascadence.scheduler import BaseScheduler, default_scheduler
+from task_cascadence.scheduler import CronScheduler, default_scheduler
 
 
 def test_sanity():
@@ -6,7 +6,7 @@ def test_sanity():
 
 
 def test_default_scheduler_available():
-    assert isinstance(default_scheduler, BaseScheduler)
+    assert isinstance(default_scheduler, CronScheduler)
 
 
 def test_example_task_registered():


### PR DESCRIPTION
## Summary
- set CronScheduler as default scheduler
- allow CronScheduler.register_task to handle old BaseScheduler signatures
- update tests for new default scheduler

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687332c441f88326a0eee91b2fd09130