### PR TITLE
Add explicit initializer for plugin setup

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -6,23 +6,20 @@ This package provides task orchestration utilities described in the PRD.
 from . import scheduler  # noqa: F401
 from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
-from . import cli  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 
 
-def _init_plugins() -> None:
-    """Initialise and load plugins."""
+def initialize() -> None:
+    """Load built-in tasks and any external plugins."""
 
     plugins.initialize()
     plugins.load_cronyx_tasks()
 
 
-_init_plugins()
+from . import cli  # noqa: F401,E402
 
 
-
-
-__all__ = ["scheduler", "plugins", "ume", "cli", "metrics", "temporal"]
+__all__ = ["scheduler", "plugins", "ume", "cli", "metrics", "temporal", "initialize"]
 
 

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -11,7 +11,8 @@ import click  # noqa: F401 - re-exported for CLI extensions
 import typer
 
 from ..scheduler import default_scheduler
-from .. import plugins  # noqa: F401  # ensure tasks are registered
+from .. import plugins  # noqa: F401
+import task_cascadence as tc
 from ..n8n import export_workflow
 
 
@@ -83,6 +84,7 @@ def main(args: list[str] | None = None) -> None:
         passed so that pytest arguments are ignored during tests.
     """
 
+    tc.initialize()
     app(args or [], standalone_mode=False)
 
 

--- a/tests/test_cronyx_integration.py
+++ b/tests/test_cronyx_integration.py
@@ -40,6 +40,7 @@ def test_tasks_loaded_from_cronyx(monkeypatch, tmp_path):
     import task_cascadence
 
     importlib.reload(task_cascadence)
+    task_cascadence.initialize()
 
     tasks = [name for name, _ in task_cascadence.scheduler.default_scheduler.list_tasks()]
     assert "remote" in tasks

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,5 @@
 from task_cascadence.scheduler import BaseScheduler, default_scheduler
+from task_cascadence import initialize
 
 
 def test_sanity():
@@ -10,7 +11,7 @@ def test_default_scheduler_available():
 
 
 def test_example_task_registered():
-    from task_cascadence import plugins  # noqa: F401 - trigger side effects
+    initialize()
 
     tasks = [name for name, _ in default_scheduler.list_tasks()]
     assert "example" in tasks

--- a/tests/test_n8n.py
+++ b/tests/test_n8n.py
@@ -4,15 +4,18 @@ from typer.testing import CliRunner
 from task_cascadence.cli import app
 from task_cascadence.scheduler import default_scheduler
 from task_cascadence.n8n import to_workflow
+from task_cascadence import initialize
 
 
 def test_to_workflow_produces_nodes():
+    initialize()
     wf = to_workflow(default_scheduler)
     assert "nodes" in wf
     assert any(n["name"] == "example" for n in wf["nodes"])
 
 
 def test_cli_export_n8n(tmp_path):
+    initialize()
     out = tmp_path / "flow.json"
     runner = CliRunner()
     result = runner.invoke(app, ["export-n8n", str(out)])


### PR DESCRIPTION
## Summary
- stop initializing plugins on import
- expose `initialize()` in `task_cascadence`
- call initializer from CLI startup
- adjust tests for explicit initialization

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687332c546e88326bb3ca9a6c373774c