### PR TITLE
Improve CI with caching and linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
 
 jobs:
   lint-test:
@@ -14,6 +15,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pip'
       - name: Check for code changes
         id: code_changes
         run: |
@@ -28,10 +30,11 @@ jobs:
         if: steps.code_changes.outputs.count != '0'
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest
+          pip install ruff pytest pytest-cov tzdata
+          pip install -e .
       - name: Run ruff
         if: steps.code_changes.outputs.count != '0'
-        run: ruff .
+        run: ruff check .
       - name: Run tests
         if: steps.code_changes.outputs.count != '0'
         run: pytest

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
-from task_cascadence.scheduler import BaseScheduler, default_scheduler
+from task_cascadence.scheduler import CronScheduler, default_scheduler
 from task_cascadence import initialize
 
 


### PR DESCRIPTION
## Summary
- run checks on pull requests as well as pushes
- cache Python packages for faster CI
- run `ruff check .` and `pytest` when code changes occur
- fix import to satisfy ruff

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742e1c8fc48326a2ae8982c37a2099