### PR TITLE
Add metrics CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ After installing the package in an environment with ``typer`` available, the
 $ task list       # show all registered tasks
 $ task run NAME   # execute a task
 $ task disable NAME  # disable a task
+$ task metrics [--port PORT]  # start the metrics server
 ```
+
+Running ``task metrics`` starts a small Prometheus server exposing
+runtime metrics on the specified port (default ``8000``).
 
 The repository ships with a single ``example`` task to demonstrate the
 mechanics.

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -10,6 +10,8 @@ import click  # noqa: F401 - re-exported for CLI extensions
 
 import typer
 
+from ..metrics import start_metrics_server
+
 from ..scheduler import default_scheduler
 from .. import plugins  # noqa: F401
 import task_cascadence as tc
@@ -74,6 +76,14 @@ def export_n8n(path: str) -> None:
         raise typer.Exit(code=1)
 
 
+@app.command("metrics")
+def metrics(port: int = 8000) -> None:
+    """Start the Prometheus metrics server."""
+
+    start_metrics_server(port)
+    typer.echo(f"metrics available on :{port}")
+
+
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
 
@@ -89,4 +99,4 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main", "export_n8n"]
+__all__ = ["app", "main", "export_n8n", "metrics"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,3 +26,18 @@ def test_manual_trigger_cli():
     runner = CliRunner()
     result = runner.invoke(app, ["trigger", "manual_demo"])
     assert result.exit_code == 0
+
+
+def test_metrics_command(monkeypatch):
+    called = {}
+
+    def fake_start(port=8000):
+        called["port"] = port
+
+    import task_cascadence.cli as cli
+
+    monkeypatch.setattr(cli, "start_metrics_server", fake_start)
+    runner = CliRunner()
+    result = runner.invoke(app, ["metrics", "--port", "9000"])
+    assert result.exit_code == 0
+    assert called["port"] == 9000

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,8 @@
-from task_cascadence.scheduler import BaseScheduler, default_scheduler
+from task_cascadence.scheduler import (
+    CronScheduler,
+    BaseScheduler,
+    default_scheduler,
+)
 from task_cascadence import initialize
 
 


### PR DESCRIPTION
## Summary
- expose a `metrics` command in the CLI
- start the Prometheus server on an optional port argument
- document `task metrics` usage
- test the new CLI command
- fix CronScheduler import in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742e1b8e288326b9a038d17be28b8e