### PR TITLE
Add webhook CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ After installing the package in an environment with ``typer`` available, the
 $ task list       # show all registered tasks
 $ task run NAME   # execute a task
 $ task disable NAME  # disable a task
+$ task webhook [--host HOST] [--port PORT]  # start webhook server
 ```
+
+``task webhook`` launches a FastAPI application that dispatches incoming
+events to any registered :class:`WebhookTask` implementations.
 
 The repository ships with a single ``example`` task to demonstrate the
 mechanics.

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -74,6 +74,18 @@ def export_n8n(path: str) -> None:
         raise typer.Exit(code=1)
 
 
+@app.command("webhook")
+def webhook(
+    host: str = typer.Option("0.0.0.0", "--host"),
+    port: int = typer.Option(8000, "--port"),
+) -> None:
+    """Start the webhook server."""
+
+    from .. import webhook as wh
+
+    wh.start_server(host=host, port=port)
+
+
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
 
@@ -89,4 +101,4 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main", "export_n8n"]
+__all__ = ["app", "main", "export_n8n", "webhook"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,3 +26,19 @@ def test_manual_trigger_cli():
     runner = CliRunner()
     result = runner.invoke(app, ["trigger", "manual_demo"])
     assert result.exit_code == 0
+
+
+def test_webhook_command_runs_uvicorn(monkeypatch):
+    called = {}
+
+    def fake_run(app, host="0.0.0.0", port=8000):
+        called["host"] = host
+        called["port"] = port
+
+    monkeypatch.setattr("task_cascadence.webhook.uvicorn.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["webhook", "--host", "127.0.0.1", "--port", "9000"])
+
+    assert result.exit_code == 0
+    assert called == {"host": "127.0.0.1", "port": 9000}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
-from task_cascadence.scheduler import BaseScheduler, default_scheduler
+from task_cascadence.scheduler import CronScheduler, default_scheduler
 from task_cascadence import initialize
 
 


### PR DESCRIPTION
## Summary
- add `webhook` command to CLI for running webhook server
- document webhook usage and options
- test CLI webhook command invokes `uvicorn.run`
- rename command function for clarity

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68742e1b97308326ad339bcbb76950b9