### PR TITLE
Add tzdata dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ crontab schedules:
 ExampleTask: "0 12 * * *"
 ```
 
+Timezone-aware scheduling requires access to the IANA timezone database.
+Install the `tzdata` package to ensure these definitions are available
+when creating schedulers with non-UTC timezones.
+
 When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This
 allows scheduled tasks to survive process restarts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "requests",
     "temporalio",
     "httpx",
+    "tzdata",
 ]
 
 [project.scripts]

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -104,5 +104,5 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main", "export_n8n", "webhook"]
+__all__ = ["app", "main", "export_n8n", "webhook", "start_metrics_server"]
 


### PR DESCRIPTION
## Summary
- add tzdata to project dependencies
- document tzdata requirement in README
- re-export `start_metrics_server` to satisfy linter

## Testing
- `ruff check .`
- `pytest tests/test_scheduler.py::test_timezone_awareness -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f8b41d0883268bf3a9eadc69ad7d