### PR TITLE
Implement schedule_task convenience method

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -104,5 +104,5 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main", "export_n8n", "webhook"]
+__all__ = ["app", "main", "export_n8n", "webhook", "start_metrics_server"]
 

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -88,8 +88,12 @@ class BaseScheduler:
 
 
     def schedule_task(self, *args, **kwargs):
-        """Stub method for scheduling tasks."""
-        pass
+        """Schedule ``task`` using ``cron_expression``.
+
+        Subclasses should override this method to provide concrete
+        scheduling behaviour.
+        """
+        raise NotImplementedError("Scheduling not implemented")
 
 
 class CronScheduler(BaseScheduler):
@@ -192,6 +196,10 @@ class CronScheduler(BaseScheduler):
         self.scheduler.add_job(
             self._wrap_task(task), trigger=trigger, id=job_id
         )
+
+    def schedule_task(self, task: Any, cron_expression: str) -> None:
+        """Convenience wrapper for :meth:`register_task`."""
+        self.register_task(task, cron_expression)
 
     def start(self):
         self.scheduler.start()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -67,3 +67,14 @@ def test_restore_schedules_on_init(tmp_path, monkeypatch):
     job.func()
     assert new_task.count == 1
 
+
+def test_schedule_task(tmp_path):
+    storage = tmp_path / "sched.yml"
+    sched = CronScheduler(timezone="UTC", storage_path=storage)
+    task = DummyTask()
+    sched.schedule_task(task, "*/2 * * * *")
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+    data = yaml.safe_load(storage.read_text())
+    assert data["DummyTask"] == "*/2 * * * *"
+


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` in the base `schedule_task`
- add a `schedule_task` method to `CronScheduler`
- expose `start_metrics_server` in CLI exports
- test new scheduling API

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f8b36e388326a781559aeaaf8fb8