### PR TITLE
Implement retriable HTTP loader

### DIFF
--- a/task_cascadence/plugins/cronyx_server.py
+++ b/task_cascadence/plugins/cronyx_server.py
@@ -1,17 +1,36 @@
+import time
+from typing import Any
+
 import requests
 
 
 class CronyxServerLoader:
     """Loader for tasks via CronyxServer's HTTP API."""
 
-    def __init__(self, base_url: str):
-        self.base_url = base_url.rstrip('/')
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 5.0,
+        retries: int = 3,
+        backoff_factor: float = 0.5,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff_factor = backoff_factor
 
-    def _get(self, path: str):
+    def _get(self, path: str) -> Any:
         url = f"{self.base_url}{path}"
-        response = requests.get(url, timeout=5)
-        response.raise_for_status()
-        return response.json()
+        for attempt in range(1, self.retries + 1):
+            try:
+                response = requests.get(url, timeout=self.timeout)
+                response.raise_for_status()
+                return response.json()
+            except requests.RequestException:
+                if attempt == self.retries:
+                    raise
+                time.sleep(self.backoff_factor * 2 ** (attempt - 1))
 
     def list_tasks(self):
         """Return a list of available tasks."""

--- a/tests/test_cronyx_server_loader.py
+++ b/tests/test_cronyx_server_loader.py
@@ -16,9 +16,47 @@ def fake_get(url, timeout):
     return DummyResponse()
 
 
+class SuccessResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"ok": True}
+
+
+def fake_success(url, timeout):
+    return SuccessResponse()
+
+
+class FailingGet:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, url, timeout):
+        self.calls += 1
+        raise requests.ConnectionError("fail")
+
+
 @pytest.mark.parametrize("method,args", [("list_tasks", ()), ("load_task", ("42",))])
 def test_loader_http_error(monkeypatch, method, args):
     loader = CronyxServerLoader("http://server")
     monkeypatch.setattr(requests, "get", fake_get)
     with pytest.raises(requests.HTTPError):
         getattr(loader, method)(*args)
+
+
+@pytest.mark.parametrize("method,args", [("list_tasks", ()), ("load_task", ("42",))])
+def test_loader_success(monkeypatch, method, args):
+    loader = CronyxServerLoader("http://server")
+    monkeypatch.setattr(requests, "get", fake_success)
+    assert getattr(loader, method)(*args) == {"ok": True}
+
+
+def test_loader_retries(monkeypatch):
+    failing = FailingGet()
+    loader = CronyxServerLoader("http://server", retries=3, backoff_factor=0)
+    monkeypatch.setattr(requests, "get", failing)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    with pytest.raises(requests.ConnectionError):
+        loader.list_tasks()
+    assert failing.calls == 3


### PR DESCRIPTION
## Summary
- wrap CronyxServerLoader requests in exponential backoff
- make request timeout configurable
- test CronyxServerLoader success and retry behaviour

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877fad3602c8326b07bd45ef2ede26d