### PR TITLE
Add tzdata dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ crontab schedules:
 ExampleTask: "0 12 * * *"
 ```
 
-Timezone-aware scheduling requires access to the IANA timezone database.
-Install the `tzdata` package to ensure these definitions are available
-when creating schedulers with non-UTC timezones.
+Timezone-aware scheduling requires access to the IANA timezone database
+provided by the `tzdata` package. Ensure this package is installed when
+creating schedulers with non-UTC timezones.
 
 When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "prometheus_client",
     "pytz",
     "pyyaml",
+    "tzdata",
     "requests",
     "temporalio",
     "httpx<0.28",


### PR DESCRIPTION
## Summary
- add `tzdata` as a project dependency
- clarify requirement for `tzdata` in the README

## Testing
- `ruff check .`
- `pytest tests/test_scheduler.py::test_timezone_awareness -q`

------
https://chatgpt.com/codex/tasks/task_e_68790cdc1eac8326bd7264b7bc8a07e9