### PR TITLE
Remove unused scheduling method

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -87,13 +87,6 @@ class BaseScheduler:
         self._tasks[name]["disabled"] = True
 
 
-    def schedule_task(self, *args, **kwargs):
-        """Schedule ``task`` using ``cron_expression``.
-
-        Subclasses should override this method to provide concrete
-        scheduling behaviour.
-        """
-        raise NotImplementedError("Scheduling not implemented")
 
 
 class CronScheduler(BaseScheduler):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,5 @@
 import yaml
-from task_cascadence.scheduler import CronScheduler
+from task_cascadence.scheduler import CronScheduler, BaseScheduler
 from task_cascadence.plugins import CronTask
 
 
@@ -80,4 +80,9 @@ def test_schedule_task(tmp_path):
     assert job is not None
     data = yaml.safe_load(storage.read_text())
     assert data["DummyTask"] == "*/2 * * * *"
+
+
+def test_base_scheduler_has_no_schedule_task():
+    bs = BaseScheduler()
+    assert not hasattr(bs, "schedule_task")
 


### PR DESCRIPTION
## Summary
- remove the unused `schedule_task` stub from `BaseScheduler`
- check that `BaseScheduler` no longer exposes `schedule_task`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68790cdd34cc832692ca56a4c26fbd2c