### PR TITLE
Pin httpx to <0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
     "pyyaml",
     "requests",
     "temporalio",
-    "httpx<0.28",
-
+    "httpx<0.28"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- pin the `httpx` dependency to `<0.28`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68790cde3d1483268d0910f19186af11