### PR TITLE
Add HTTP retry helper and configurable timeout

### DIFF
--- a/task_cascadence/http_utils.py
+++ b/task_cascadence/http_utils.py
@@ -1,0 +1,28 @@
+import time
+from typing import Any, Optional
+
+import requests
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+    session: Optional[requests.Session] = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Perform an HTTP request with simple retry logic."""
+    sess = session or requests
+    for attempt in range(1, retries + 1):
+        try:
+            response = sess.request(method, url, timeout=timeout, **kwargs)
+            response.raise_for_status()
+            return response
+        except requests.RequestException:
+            if attempt == retries:
+                raise
+            time.sleep(backoff_factor * 2 ** (attempt - 1))
+    raise RuntimeError("unreachable")


### PR DESCRIPTION
## Summary
- centralize retry logic in `http_utils.request_with_retry`
- use it in `CronyxServerLoader` and read default timeout from `CRONYX_TIMEOUT`
- update loader tests for new behavior and add timeout env test

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879113c79608326a377c21cbde33815