### PR TITLE
Emit TaskRun from scheduler

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,12 +17,18 @@ def test_cli_main_returns_none():
 
 class ManualTask(ManualTrigger):
     name = "manual_demo"
+
     def run(self):
         return "ok"
 
 
-def test_manual_trigger_cli():
+def test_manual_trigger_cli(monkeypatch):
     default_scheduler.register_task("manual_demo", ManualTask())
+
+    from task_cascadence import ume
+
+    monkeypatch.setattr(ume, "emit_task_run", lambda run: None)
+
     runner = CliRunner()
     result = runner.invoke(app, ["trigger", "manual_demo"])
     assert result.exit_code == 0

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -28,7 +28,10 @@ def test_emit_task_run_within_deadline():
     start = time.monotonic()
     emit_task_run(run, client)
     assert client.events
-    delay = client.events[0][1] - start
+    queued, ts = client.events[0]
+    assert isinstance(queued, TaskRun)
+    assert queued == run
+    delay = ts - start
     assert delay < 0.2
 
 
@@ -38,5 +41,8 @@ def test_emit_task_spec_within_deadline():
     start = time.monotonic()
     emit_task_spec(spec, client)
     assert client.events
-    delay = client.events[0][1] - start
+    queued, ts = client.events[0]
+    assert isinstance(queued, TaskSpec)
+    assert queued == spec
+    delay = ts - start
     assert delay < 0.2


### PR DESCRIPTION
## Summary
- emit TaskRun metadata when running tasks manually via `run_task`
- verify queued objects are TaskRun/TaskSpec in emitter tests
- patch CLI tests to stub out `emit_task_run`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879113b9c9483269168d0fe9ec66874