### PR TITLE
Switch scheduler timezones to zoneinfo

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -6,11 +6,12 @@ can interact with tasks without pulling in heavy dependencies like
 APScheduler.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from zoneinfo import ZoneInfo
 import yaml
 
 
@@ -18,6 +19,7 @@ from typing import Any, Dict, Iterable, Tuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from ..plugins import BaseTask  # noqa: F401
+    from zoneinfo import ZoneInfo
 
 
 from ..temporal import TemporalBackend
@@ -106,6 +108,8 @@ class CronScheduler(BaseScheduler):
 
     ):
         super().__init__(temporal=temporal)
+
+        from zoneinfo import ZoneInfo
 
         self._CronTrigger = CronTrigger
         self._yaml = yaml

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -18,7 +18,10 @@ def test_timezone_awareness(tmp_path):
     task = DummyTask()
     sched.register_task(task, "0 12 * * *")
     job = sched.scheduler.get_job("DummyTask")
+    from zoneinfo import ZoneInfo
+
     assert str(job.trigger.timezone) == "US/Pacific"
+    assert isinstance(job.trigger.timezone, ZoneInfo)
 
 
 def test_schedule_persistence(tmp_path):


### PR DESCRIPTION
## Summary
- load `ZoneInfo` dynamically in `CronScheduler.__init__`
- ensure tests confirm zoneinfo timezone objects

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879113aa7c08326b9e0a1fe0c621c8d