### PR TITLE
Add test for Cal.com webhook

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -43,3 +43,25 @@ def test_registered_task_receives_event():
 
     assert response.json() == {"status": "received"}
     assert CollectorTask.events == [("github", "issues", payload)]
+
+
+def test_calcom_task_receives_event():
+    """Webhook tasks should receive Cal.com events."""
+
+    webhook_task_registry.clear()
+
+    @register_webhook_task
+    class CollectorTask(WebhookTask):
+        events = []
+
+        def handle_event(self, source, event_type, payload):
+            self.__class__.events.append((source, event_type, payload))
+
+    client = TestClient(app)
+    payload = {"event": "created"}
+    headers = {"Cal-Event-Type": "booking"}
+
+    response = client.post("/webhook/calcom", json=payload, headers=headers)
+
+    assert response.json() == {"status": "received"}
+    assert CollectorTask.events == [("calcom", "booking", payload)]


### PR DESCRIPTION
## Summary
- ensure that posting to `/webhook/calcom` delivers events to webhook tasks

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793e18d9b88326af9aa4440c4f7668