### PR TITLE
Add metrics port option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ $ task disable NAME  # disable a task
 $ task webhook [--host HOST] [--port PORT]  # start webhook server
 ```
 
+Use ``--metrics-port PORT`` with any command to expose Prometheus metrics:
+
+```bash
+$ task --metrics-port 9000 run example
+```
+
+Metrics will then be available on ``http://localhost:9000/metrics``.
+
 ``task webhook`` launches a FastAPI application that dispatches incoming
 events to any registered :class:`WebhookTask` implementations.
 

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -12,11 +12,26 @@ import typer
 
 from ..scheduler import default_scheduler
 from .. import plugins  # noqa: F401
+from ..metrics import start_metrics_server  # noqa: F401
 import task_cascadence as tc
 from ..n8n import export_workflow
 
 
 app = typer.Typer(help="Interact with Cascadence tasks")
+
+
+@app.callback()
+def _global_options(
+    metrics_port: int | None = typer.Option(
+        None,
+        "--metrics-port",
+        help="Expose Prometheus metrics on PORT before executing the command",
+    )
+) -> None:
+    """Handle global options for the CLI."""
+
+    if metrics_port is not None:
+        start_metrics_server(metrics_port)
 
 
 @app.command("list")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,3 +49,19 @@ def test_webhook_command_runs_uvicorn(monkeypatch):
     assert result.exit_code == 0
     assert called == {"host": "127.0.0.1", "port": 9000}
 
+
+def test_metrics_option_starts_server(monkeypatch):
+    called = {}
+
+    def fake_start(port: int):
+        called["port"] = port
+
+    import task_cascadence.cli as cli
+    monkeypatch.setattr(cli, "start_metrics_server", fake_start)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--metrics-port", "9100", "list"])
+
+    assert result.exit_code == 0
+    assert called["port"] == 9100
+


### PR DESCRIPTION
## Summary
- add a `--metrics-port` global option in the CLI that starts Prometheus metrics
- document how to expose metrics via CLI in README
- test that CLI invokes the metrics server when the option is used

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793e174d448326803bfd9f4a7ff291