### PR TITLE
Add default scheduler accessor

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -3,11 +3,14 @@
 This package provides task orchestration utilities described in the PRD.
 """
 
-from . import scheduler  # noqa: F401
+from .scheduler import get_default_scheduler  # noqa: F401
 from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
+
+# Ensure the default scheduler is created on import
+get_default_scheduler()
 
 
 def initialize() -> None:

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -10,11 +10,13 @@ import click  # noqa: F401 - re-exported for CLI extensions
 
 import typer
 
-from ..scheduler import default_scheduler
+from ..scheduler import get_default_scheduler
 from .. import plugins  # noqa: F401
 from ..metrics import start_metrics_server  # noqa: F401
 import task_cascadence as tc
 from ..n8n import export_workflow
+
+default_scheduler = get_default_scheduler()
 
 
 app = typer.Typer(help="Interact with Cascadence tasks")
@@ -96,7 +98,7 @@ def schedule_task(name: str, expression: str) -> None:
         typer.echo(f"{name} scheduled: {expression}")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command("export-n8n")

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -12,7 +12,9 @@ from importlib import metadata
 from typing import Dict
 
 
-from ..scheduler import default_scheduler
+from ..scheduler import get_default_scheduler
+
+default_scheduler = get_default_scheduler()
 
 
 class BaseTask:

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -249,9 +249,21 @@ class CronScheduler(BaseScheduler):
 
 
 # ---------------------------------------------------------------------------
-# A default scheduler instance used by the CLI and plugin registration. Tests
-# expect this object to exist at module scope.
+# Default scheduler accessor
 
-default_scheduler = CronScheduler()
+_default_scheduler: CronScheduler | None = None
+
+
+def get_default_scheduler() -> CronScheduler:
+    """Return a singleton :class:`CronScheduler` instance."""
+
+    global _default_scheduler
+    if _default_scheduler is None:
+        _default_scheduler = CronScheduler()
+    return _default_scheduler
+
+
+# Backwards compatibility alias
+default_scheduler = get_default_scheduler()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from task_cascadence.cli import app, main
 from task_cascadence.plugins import ManualTrigger, CronTask
-from task_cascadence.scheduler import default_scheduler
+from task_cascadence.scheduler import get_default_scheduler
 from task_cascadence.temporal import TemporalBackend
 
 
@@ -24,7 +24,8 @@ class ManualTask(ManualTrigger):
 
 
 def test_manual_trigger_cli(monkeypatch):
-    default_scheduler.register_task("manual_demo", ManualTask())
+    sched = get_default_scheduler()
+    sched.register_task("manual_demo", ManualTask())
 
     from task_cascadence import ume
 
@@ -41,8 +42,9 @@ class DummyTask(CronTask):
 
 def test_run_command_temporal(monkeypatch):
     backend = TemporalBackend()
-    default_scheduler._temporal = backend
-    default_scheduler.register_task("dummy", DummyTask())
+    sched = get_default_scheduler()
+    sched._temporal = backend
+    sched.register_task("dummy", DummyTask())
 
     called = {}
 

--- a/tests/test_cronyx_integration.py
+++ b/tests/test_cronyx_integration.py
@@ -42,5 +42,7 @@ def test_tasks_loaded_from_cronyx(monkeypatch, tmp_path):
     importlib.reload(task_cascadence)
     task_cascadence.initialize()
 
-    tasks = [name for name, _ in task_cascadence.scheduler.default_scheduler.list_tasks()]
+    tasks = [
+        name for name, _ in task_cascadence.scheduler.get_default_scheduler().list_tasks()
+    ]
     assert "remote" in tasks

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
-from task_cascadence.scheduler import CronScheduler, default_scheduler
+from task_cascadence.scheduler import CronScheduler, get_default_scheduler
 
 from task_cascadence import initialize
 
@@ -9,11 +9,11 @@ def test_sanity():
 
 
 def test_default_scheduler_available():
-    assert isinstance(default_scheduler, CronScheduler)
+    assert isinstance(get_default_scheduler(), CronScheduler)
 
 
 def test_example_task_registered():
     initialize()
 
-    tasks = [name for name, _ in default_scheduler.list_tasks()]
+    tasks = [name for name, _ in get_default_scheduler().list_tasks()]
     assert "example" in tasks

--- a/tests/test_n8n.py
+++ b/tests/test_n8n.py
@@ -2,14 +2,14 @@ import json
 from typer.testing import CliRunner
 
 from task_cascadence.cli import app
-from task_cascadence.scheduler import default_scheduler
+from task_cascadence.scheduler import get_default_scheduler
 from task_cascadence.n8n import to_workflow
 from task_cascadence import initialize
 
 
 def test_to_workflow_produces_nodes():
     initialize()
-    wf = to_workflow(default_scheduler)
+    wf = to_workflow(get_default_scheduler())
     assert "nodes" in wf
     assert any(n["name"] == "example" for n in wf["nodes"])
 


### PR DESCRIPTION
## Summary
- create `get_default_scheduler()` singleton accessor
- use accessor in CLI and plugin modules
- instantiate scheduler on package import
- update tests for new accessor

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9ecfd5e08326868cdb0cb892a85a