### PR TITLE
Instrument scheduler metrics

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -96,7 +96,7 @@ def schedule_task(name: str, expression: str) -> None:
         typer.echo(f"{name} scheduled: {expression}")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command("export-n8n")

--- a/task_cascadence/metrics.py
+++ b/task_cascadence/metrics.py
@@ -4,6 +4,14 @@ from prometheus_client import Counter, Histogram, start_http_server
 import functools
 import time
 
+# Public exports
+__all__ = [
+    "TASK_LATENCY",
+    "TASK_SUCCESS",
+    "TASK_FAILURE",
+    "start_metrics_server",
+    "track_task",
+]
 # Histogram tracking how long each task takes to run.
 TASK_LATENCY = Histogram(
     "task_latency_seconds",

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 
 
 from ..temporal import TemporalBackend
+from .. import metrics
 
 
 class BaseScheduler:
@@ -171,6 +172,7 @@ class CronScheduler(BaseScheduler):
             self._yaml.safe_dump(self.schedules, fh)
 
     def _wrap_task(self, task):
+        @metrics.track_task
         def runner():
             from datetime import datetime
             from uuid import uuid4


### PR DESCRIPTION
## Summary
- export `track_task` via `__all__`
- instrument `CronScheduler` runners with metrics
- add metric test for scheduled jobs
- fix B904 style warning in CLI

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a9ed01bd08326b9be6b55c1ac725c