### PR TITLE
Add user_id hashing for UME events

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This
 allows scheduled tasks to survive process restarts.
 
+## User Identification
+
+``emit_task_spec`` and ``emit_task_run`` accept an optional ``user_id``
+parameter. The value is hashed with SHA-256 and stored in the ``user_hash``
+field of the emitted dataclass. Raw identifiers are never sent over the wire,
+allowing user-aware analytics without exposing sensitive information.
+
+```python
+from task_cascadence import ume
+
+ume.emit_task_spec(spec, user_id="alice")
+```
+
 ## Plugin Discovery
 
 Additional tasks can be provided by external packages using the

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -12,6 +12,7 @@ class TaskSpec:
     id: str
     name: str
     description: Optional[str] = None
+    user_hash: Optional[str] = None
 
 
 @dataclass
@@ -23,3 +24,4 @@ class TaskRun:
     status: str
     started_at: datetime
     finished_at: datetime
+    user_hash: Optional[str] = None

--- a/tests/test_user_hash.py
+++ b/tests/test_user_hash.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from task_cascadence.ume import emit_task_spec, emit_task_run
+from task_cascadence.ume.models import TaskSpec, TaskRun
+
+
+class Collector:
+    def __init__(self):
+        self.events = []
+
+    def enqueue(self, obj):
+        self.events.append(obj)
+
+def test_spec_user_hashes_unique():
+    client = Collector()
+    spec1 = TaskSpec(id="1", name="a")
+    spec2 = TaskSpec(id="2", name="b")
+    emit_task_spec(spec1, client, user_id="alice")
+    emit_task_spec(spec2, client, user_id="bob")
+    h1 = client.events[0].user_hash
+    h2 = client.events[1].user_hash
+    assert h1 != h2
+    assert h1 != "alice"
+    assert h2 != "bob"
+
+def test_run_user_hash_not_raw():
+    client = Collector()
+    spec = TaskSpec(id="3", name="c")
+    run = TaskRun(
+        spec=spec,
+        run_id="r1",
+        status="ok",
+        started_at=datetime.now(),
+        finished_at=datetime.now(),
+    )
+    emit_task_run(run, client, user_id="alice")
+    assert client.events[0].user_hash != "alice"
+


### PR DESCRIPTION
## Summary
- support hashed user identifiers in TaskSpec and TaskRun
- emit hashed IDs via `emit_task_spec` and `emit_task_run`
- document user identification
- test that hashes differ and raw IDs aren't sent

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa313b6708326bc6f948d0ac3995f