### PR TITLE
Add configurable scheduler backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ When a new ``CronScheduler`` instance starts it reads this file and re-creates
 any jobs for which task objects are supplied via the ``tasks`` argument.  This
 allows scheduled tasks to survive process restarts.
 
+## Scheduler Backend
+
+``task_cascadence.initialize`` reads configuration to decide which scheduler
+backend to instantiate. By default the cron-based scheduler is used. Set the
+``CASCADENCE_SCHEDULER`` environment variable to ``base`` or provide a YAML file
+via ``CASCADENCE_CONFIG`` containing::
+
+    scheduler: base
+
+This will select the simple in-memory scheduler instead.
+
 ## Plugin Discovery
 
 Additional tasks can be provided by external packages using the

--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -3,18 +3,32 @@
 This package provides task orchestration utilities described in the PRD.
 """
 
-from .scheduler import get_default_scheduler  # noqa: F401
+from .scheduler import (
+    set_default_scheduler,
+    CronScheduler,
+    BaseScheduler,
+)
 from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
+from .config import load_config
 
-# Ensure the default scheduler is created on import
-get_default_scheduler()
+
 
 
 def initialize() -> None:
     """Load built-in tasks and any external plugins."""
+
+    cfg = load_config()
+    backend = cfg.get("scheduler", "cron")
+    if backend == "cron":
+        sched = CronScheduler()
+    elif backend == "base":
+        sched = BaseScheduler()
+    else:
+        raise ValueError(f"Unknown scheduler backend: {backend}")
+    set_default_scheduler(sched)
 
     plugins.initialize()
     plugins.load_cronyx_tasks()

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -1,0 +1,28 @@
+"""Configuration helpers for Cascadence."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Load configuration from ``path`` or ``CASCADENCE_CONFIG`` env var.
+
+    The configuration currently supports selecting the scheduler backend via the
+    ``scheduler`` key. Environment variable ``CASCADENCE_SCHEDULER`` overrides
+    any value found in the YAML file. If no configuration is provided the
+    scheduler defaults to ``cron``.
+    """
+
+    cfg: Dict[str, Any] = {}
+    path = path or os.getenv("CASCADENCE_CONFIG")
+    if path and os.path.exists(path):
+        with open(path, "r") as fh:
+            cfg = yaml.safe_load(fh) or {}
+    scheduler = os.getenv("CASCADENCE_SCHEDULER", cfg.get("scheduler", "cron"))
+    cfg["scheduler"] = scheduler
+    return cfg
+

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -14,8 +14,6 @@ from typing import Dict
 
 from ..scheduler import get_default_scheduler
 
-default_scheduler = get_default_scheduler()
-
 
 class BaseTask:
     """Base class for all tasks."""
@@ -93,7 +91,7 @@ def load_entrypoint_plugins() -> None:
     for ep in metadata.entry_points().select(group="task_cascadence.plugins"):
         task = load_plugin(ep.value)
         registered_tasks[task.name] = task
-        default_scheduler.register_task(task.name, task)
+        get_default_scheduler().register_task(task.name, task)
 
 
 def load_cronyx_plugins(base_url: str) -> None:
@@ -106,14 +104,14 @@ def load_cronyx_plugins(base_url: str) -> None:
         data = loader.load_task(info["id"])
         task = load_plugin(data["path"])
         registered_tasks[task.name] = task
-        default_scheduler.register_task(task.name, task)
+        get_default_scheduler().register_task(task.name, task)
 
 
 def initialize() -> None:
     """Register built-in tasks and load any external plugins."""
 
     for _name, _task in registered_tasks.items():
-        default_scheduler.register_task(_name, _task)
+        get_default_scheduler().register_task(_name, _task)
 
     load_entrypoint_plugins()
 
@@ -138,7 +136,7 @@ def load_cronyx_tasks() -> None:
             cls = getattr(mod, cls_name)
             obj = cls()
             registered_tasks[obj.name] = obj
-            default_scheduler.register_task(obj.name, obj)
+            get_default_scheduler().register_task(obj.name, obj)
     except Exception:  # pragma: no cover - best effort loading
         pass
 

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -253,19 +253,25 @@ class CronScheduler(BaseScheduler):
 # ---------------------------------------------------------------------------
 # Default scheduler accessor
 
-_default_scheduler: CronScheduler | None = None
+_default_scheduler: BaseScheduler | None = None
 
 
-def get_default_scheduler() -> CronScheduler:
-    """Return a singleton :class:`CronScheduler` instance."""
+def set_default_scheduler(scheduler: BaseScheduler) -> None:
+    """Set the global default scheduler instance."""
 
     global _default_scheduler
+    _default_scheduler = scheduler
+
+
+def get_default_scheduler() -> BaseScheduler:
+    """Return the configured default scheduler."""
+
     if _default_scheduler is None:
-        _default_scheduler = CronScheduler()
+        raise RuntimeError("Default scheduler has not been initialised")
     return _default_scheduler
 
 
 # Backwards compatibility alias
-default_scheduler = get_default_scheduler()
+default_scheduler = get_default_scheduler
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 from task_cascadence.cli import app, main
 from task_cascadence.plugins import ManualTrigger, CronTask
 from task_cascadence.scheduler import get_default_scheduler
+from task_cascadence import initialize
 from task_cascadence.temporal import TemporalBackend
 
 
@@ -24,6 +25,7 @@ class ManualTask(ManualTrigger):
 
 
 def test_manual_trigger_cli(monkeypatch):
+    initialize()
     sched = get_default_scheduler()
     sched.register_task("manual_demo", ManualTask())
 
@@ -42,6 +44,7 @@ class DummyTask(CronTask):
 
 def test_run_command_temporal(monkeypatch):
     backend = TemporalBackend()
+    initialize()
     sched = get_default_scheduler()
     sched._temporal = backend
     sched.register_task("dummy", DummyTask())
@@ -82,7 +85,7 @@ def test_cli_schedule_creates_entry(monkeypatch, tmp_path):
     import yaml
 
     sched = CronScheduler(storage_path=tmp_path / "sched.yml")
-    monkeypatch.setattr("task_cascadence.cli.default_scheduler", sched)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
     sched.register_task("example", ExampleTask())
 
     runner = CliRunner()
@@ -97,7 +100,7 @@ def test_cli_schedule_unknown_task(monkeypatch):
     from task_cascadence.scheduler import CronScheduler
 
     sched = CronScheduler(storage_path="/tmp/dummy.yml")
-    monkeypatch.setattr("task_cascadence.cli.default_scheduler", sched)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
 
     runner = CliRunner()
     result = runner.invoke(app, ["schedule", "missing", "* * * * *"])

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+
+import task_cascadence
+from task_cascadence.scheduler import get_default_scheduler, BaseScheduler, CronScheduler
+
+
+def test_env_selects_base_scheduler(monkeypatch):
+    monkeypatch.setenv("CASCADENCE_SCHEDULER", "base")
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    assert isinstance(get_default_scheduler(), BaseScheduler)
+
+
+def test_yaml_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("scheduler: base")
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
+    if "CASCADENCE_SCHEDULER" in os.environ:
+        monkeypatch.delenv("CASCADENCE_SCHEDULER", raising=False)
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    assert isinstance(get_default_scheduler(), BaseScheduler)
+
+
+def test_env_overrides_yaml(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("scheduler: base")
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
+    monkeypatch.setenv("CASCADENCE_SCHEDULER", "cron")
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    assert isinstance(get_default_scheduler(), CronScheduler)
+

--- a/tests/test_entrypoint_discovery.py
+++ b/tests/test_entrypoint_discovery.py
@@ -21,12 +21,13 @@ def test_entrypoint_loading(monkeypatch):
     ep = metadata.EntryPoint(name="ep", value="ep_mod:PluginTask", group="task_cascadence.plugins")
     monkeypatch.setattr(metadata, "entry_points", lambda: metadata.EntryPoints([ep]))
 
-    import task_cascadence.plugins as pl
-    importlib.reload(pl)
-    pl.initialize()
+    import task_cascadence
+    importlib.reload(task_cascadence.plugins)
+    task_cascadence.initialize()
     import importlib as _importlib
     import task_cascadence.webhook as wh
     _importlib.reload(wh)
 
+    import task_cascadence.plugins as pl
     assert "ep" in pl.registered_tasks
     assert isinstance(pl.registered_tasks["ep"], PluginTask)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,5 +1,4 @@
 from task_cascadence.scheduler import CronScheduler, get_default_scheduler
-
 from task_cascadence import initialize
 
 
@@ -9,6 +8,7 @@ def test_sanity():
 
 
 def test_default_scheduler_available():
+    initialize()
     assert isinstance(get_default_scheduler(), CronScheduler)
 
 


### PR DESCRIPTION
## Summary
- support env/YAML config for scheduler backend
- instantiate scheduler in `initialize()` according to config
- lazily fetch scheduler in plugins and CLI
- document scheduler backend configuration
- cover config loader in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa3145c948326b897f5fd1939483f