### PR TITLE
Add plugin reload watcher and CLI command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "requests",
     "temporalio",
     "httpx<0.28",  # pinned for compatibility with temporalio
+    "watchdog",
 ]
 
 [project.scripts]

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -125,6 +125,18 @@ def webhook(
     wh.start_server(host=host, port=port)
 
 
+@app.command("reload-plugins")
+def reload_plugins_cmd() -> None:
+    """Reload installed plugins and refresh the scheduler."""
+
+    from .. import plugins as pl
+    pl.reload_plugins()
+
+    global default_scheduler
+    default_scheduler = get_default_scheduler()
+    typer.echo("plugins reloaded")
+
+
 
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
@@ -141,5 +153,12 @@ def main(args: list[str] | None = None) -> None:
 
 
 
-__all__ = ["app", "main", "export_n8n", "webhook", "start_metrics_server"]
+__all__ = [
+    "app",
+    "main",
+    "export_n8n",
+    "webhook",
+    "start_metrics_server",
+    "reload_plugins_cmd",
+]
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -142,3 +142,20 @@ def load_cronyx_tasks() -> None:
     except Exception:  # pragma: no cover - best effort loading
         pass
 
+
+def reload_plugins() -> None:
+    """Reload plugin modules and reset the default scheduler."""
+
+    from importlib import reload, invalidate_caches
+    from .. import scheduler as _scheduler
+
+    for task in registered_tasks.values():
+        mod = task.__class__.__module__
+        if mod != __name__ and mod in sys.modules:
+            del sys.modules[mod]
+
+    invalidate_caches()
+    _scheduler._default_scheduler = None  # reset singleton
+    reload(sys.modules[__name__])
+    sys.modules[__name__].initialize()
+

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers.polling import PollingObserver as Observer
+
+from . import reload_plugins
+
+
+class _ReloadHandler(FileSystemEventHandler):
+    """Internal handler that reloads plugins on any file change."""
+
+    def on_any_event(self, event):  # pragma: no cover - simple passthrough
+        if event.is_directory:
+            return
+        reload_plugins()
+
+
+class PluginWatcher:
+    """Watch a directory for plugin changes and reload."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._observer = Observer()
+        self._handler = _ReloadHandler()
+
+    def start(self) -> None:
+        """Start watching the directory."""
+        self._observer.schedule(self._handler, str(self.path), recursive=True)
+        self._observer.start()
+
+    def stop(self) -> None:
+        """Stop watching."""
+        self._observer.stop()
+        self._observer.join()

--- a/tests/test_plugin_reload.py
+++ b/tests/test_plugin_reload.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+import time
+from importlib import metadata
+
+from typer.testing import CliRunner
+
+from task_cascadence.cli import app
+from task_cascadence import plugins as pl
+from task_cascadence.plugins.watcher import PluginWatcher
+
+
+PLUGIN_V1 = (
+    "from task_cascadence.plugins import CronTask\n"
+    "class Plugin(CronTask):\n"
+    "    name = 'ep'\n"
+    "    def run(self):\n"
+    "        return 'v1'\n"
+)
+
+PLUGIN_V2 = (
+    "from task_cascadence.plugins import CronTask\n"
+    "class Plugin(CronTask):\n"
+    "    name = 'ep'\n"
+    "    def run(self):\n"
+    "        return 'v2'\n"
+)
+
+
+def setup_plugin(tmp_path, monkeypatch, content):
+    module = tmp_path / "plug.py"
+    module.write_text(content)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = metadata.EntryPoint(name="ep", value="plug:Plugin", group="task_cascadence.plugins")
+    monkeypatch.setattr(metadata, "entry_points", lambda: metadata.EntryPoints([ep]))
+    if "plug" in sys.modules:
+        del sys.modules["plug"]
+    importlib.reload(pl)
+    pl.initialize()
+    return module
+
+
+def test_cli_reload_plugins(tmp_path, monkeypatch):
+    module = setup_plugin(tmp_path, monkeypatch, PLUGIN_V1)
+
+    assert pl.registered_tasks["ep"].run() == "v1"
+
+    runner = CliRunner()
+    time.sleep(1)
+    module.write_text(PLUGIN_V2)
+    result = runner.invoke(app, ["reload-plugins"])
+    assert result.exit_code == 0
+
+    pl_mod = importlib.reload(pl)
+    pl_mod.initialize()
+    assert pl_mod.registered_tasks["ep"].run() == "v2"
+
+
+def test_plugin_watcher_auto_reload(tmp_path, monkeypatch):
+    module = setup_plugin(tmp_path, monkeypatch, PLUGIN_V1)
+    assert pl.registered_tasks["ep"].run() == "v1"
+
+    watcher = PluginWatcher(tmp_path)
+    watcher.start()
+    try:
+        time.sleep(1)
+        module.write_text(PLUGIN_V2)
+        time.sleep(1)
+    finally:
+        watcher.stop()
+    pl_mod = importlib.reload(pl)
+    pl_mod.initialize()
+    assert pl_mod.registered_tasks["ep"].run() == "v2"


### PR DESCRIPTION
## Summary
- add `watchdog` dependency
- implement plugin reloading and watcher
- expose `reload-plugins` CLI command
- add tests covering plugin reload behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa31335248326a70bc1e9daab2fe6