### PR TITLE
Update plugin docs with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Plugins implemented in Rust or Go can be built and served via a CronyxServer
 instance. Set the ``CRONYX_BASE_URL`` environment variable to the server's URL
 and Cascadence will fetch and register any advertised tasks on startup. Example
 plugin source for Python, Rust and Go lives in the ``examples/`` directory.
+See the [Go plugin README](examples/go_plugin/README.md) and
+[Rust plugin README](examples/rust_plugin/README.md) for build instructions.
 
 ## n8n Export
 

--- a/examples/go_plugin/README.md
+++ b/examples/go_plugin/README.md
@@ -3,3 +3,23 @@
 This directory shows how a Go based plugin might expose tasks through a
 CronyxServer compatible API. The `go.mod` file defines a simple module and the
 `main.go` implements a stub HTTP server returning task metadata.
+
+## Building
+
+Use the standard Go toolchain to create a binary:
+
+```bash
+go build -o go_cronyx_plugin .
+```
+
+## Serving
+
+Run the compiled binary and point Cascadence at the CronyxServer by
+setting the ``CRONYX_BASE_URL`` environment variable before starting
+Cascadence:
+
+```bash
+./go_cronyx_plugin &
+export CRONYX_BASE_URL=http://localhost:8000
+# now run Cascadence normally
+```

--- a/examples/rust_plugin/README.md
+++ b/examples/rust_plugin/README.md
@@ -1,5 +1,24 @@
 # Rust Cronyx Plugin
 
-This directory contains a minimal Rust plugin that exposes tasks via CronyxServer.
-The `Cargo.toml` includes the necessary metadata and a simple `main.rs` that
-registers a task and serves it over HTTP for discovery.
+This directory contains a minimal Rust plugin that exposes tasks via
+CronyxServer. The `Cargo.toml` includes the necessary metadata and a simple
+`main.rs` that registers a task and serves it over HTTP for discovery.
+
+## Building
+
+Compile the plugin using Cargo:
+
+```bash
+cargo build --release
+```
+
+## Serving
+
+Start the server binary and set ``CRONYX_BASE_URL`` so Cascadence can fetch the
+advertised tasks:
+
+```bash
+./target/release/rustplugin &
+export CRONYX_BASE_URL=http://localhost:8000
+# start Cascadence as usual
+```


### PR DESCRIPTION
## Summary
- document how to build and serve the Go and Rust example plugins
- explain `CRONYX_BASE_URL` usage
- link plugin READMEs from the main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aa6e1afb883269a1f3c3ed4ab8772