### PR TITLE
Add CLI transport configuration

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -154,6 +154,7 @@ def reload_plugins() -> None:
 
     invalidate_caches()
     _scheduler._default_scheduler = None  # reset singleton
+    _scheduler.set_default_scheduler(_scheduler.CronScheduler())
     reload(sys.modules[__name__])
     sys.modules[__name__].initialize()
 


### PR DESCRIPTION
## Summary
- enable plugin reload to create a new scheduler
- extend CLI global options to configure UME transports
- test CLI transport configuration

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa6dd95fc832698bd44ba31ce06a7