### PR TITLE
Add ruff lint step and fix imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff pytest pytest-cov tzdata
           pip install -e .
-      - name: Run ruff
+      - name: Run ruff check
         if: steps.code_changes.outputs.count != '0'
         run: ruff check .
       - name: Run tests

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import click  # noqa: F401 - re-exported for CLI extensions
 
+import importlib
 import typer
 
 from ..scheduler import get_default_scheduler, default_scheduler
@@ -69,12 +70,12 @@ def _global_options(
             if grpc_stub is None:
                 raise typer.BadParameter("--grpc-stub is required for grpc transport")
             stub = _load(grpc_stub)
-            ume.configure_transport("grpc", stub=stub, method=grpc_method)
+            tc.ume.configure_transport("grpc", stub=stub, method=grpc_method)
         elif transport == "nats":
             if nats_conn is None:
                 raise typer.BadParameter("--nats-conn is required for nats transport")
             conn = _load(nats_conn)
-            ume.configure_transport("nats", connection=conn, subject=nats_subject)
+            tc.ume.configure_transport("nats", connection=conn, subject=nats_subject)
         else:  # pragma: no cover - validation by typer
             raise typer.BadParameter(f"Unknown transport: {transport}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,6 @@
 from click.exceptions import UsageError
 import pytest
 from typer.testing import CliRunner
-import types
-import sys
 
 from task_cascadence.cli import app, main
 from task_cascadence.plugins import ManualTrigger, CronTask


### PR DESCRIPTION
## Summary
- run `ruff check` in CI explicitly
- fix CLI imports so ruff passes
- clean up unused imports in the CLI tests

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d26b7ceb88326a6312164a1ef014d