### PR TITLE
Fix CLI imports and add transport option test

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 import click  # noqa: F401 - re-exported for CLI extensions
 
 import typer
+import importlib
+
+from .. import ume
 
 from ..scheduler import get_default_scheduler, default_scheduler
 


### PR DESCRIPTION
## Summary
- import `importlib` and `ume` in CLI
- test CLI `--transport` option via `grpc` stub

## Testing
- `ruff check task_cascadence/cli/__init__.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d26b6a8a88326ba7c73326e519a77