### PR TITLE
Add Cronyx auto-refresh schedule

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -13,6 +13,7 @@ from . import ume  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
 from .config import load_config
+from apscheduler.triggers.cron import CronTrigger
 
 
 
@@ -32,6 +33,17 @@ def initialize() -> None:
 
     plugins.initialize()
     plugins.load_cronyx_tasks()
+
+    if cfg.get("cronyx_refresh", True) and isinstance(sched, CronScheduler):
+        trigger = CronTrigger.from_crontab(
+            "*/10 * * * *", timezone=sched.scheduler.timezone
+        )
+        sched.scheduler.add_job(
+            plugins.load_cronyx_tasks,
+            trigger=trigger,
+            id="cronyx_refresh",
+            replace_existing=True,
+        )
 
 
 from . import cli  # noqa: F401,E402

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -10,9 +10,6 @@ import click  # noqa: F401 - re-exported for CLI extensions
 
 import importlib
 import typer
-import importlib
-
-from .. import ume
 
 from ..scheduler import get_default_scheduler, default_scheduler
 

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -24,5 +24,12 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
             cfg = yaml.safe_load(fh) or {}
     scheduler = os.getenv("CASCADENCE_SCHEDULER", cfg.get("scheduler", "cron"))
     cfg["scheduler"] = scheduler
+
+    refresh_env = os.getenv("CASCADENCE_CRONYX_REFRESH")
+    if refresh_env is not None:
+        cfg["cronyx_refresh"] = refresh_env.lower() not in ("0", "false", "no")
+    else:
+        cfg["cronyx_refresh"] = bool(cfg.get("cronyx_refresh", True))
+
     return cfg
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -32,3 +32,11 @@ def test_env_overrides_yaml(monkeypatch, tmp_path):
     task_cascadence.initialize()
     assert isinstance(get_default_scheduler(), CronScheduler)
 
+
+def test_disable_cronyx_refresh(monkeypatch):
+    monkeypatch.setenv("CASCADENCE_CRONYX_REFRESH", "0")
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    sched = get_default_scheduler()
+    assert sched.scheduler.get_job("cronyx_refresh") is None
+

--- a/tests/test_cronyx_integration.py
+++ b/tests/test_cronyx_integration.py
@@ -46,3 +46,83 @@ def test_tasks_loaded_from_cronyx(monkeypatch, tmp_path):
         name for name, _ in task_cascadence.scheduler.get_default_scheduler().list_tasks()
     ]
     assert "remote" in tasks
+
+
+def test_cronyx_refresh_job(monkeypatch, tmp_path):
+    mod1 = tmp_path / "mod1.py"
+    mod1.write_text(
+        dedent(
+            """
+            from task_cascadence.plugins import CronTask
+
+            class T1(CronTask):
+                name = "t1"
+
+                def run(self):
+                    return "t1"
+            """
+        )
+    )
+    mod2 = tmp_path / "mod2.py"
+    mod2.write_text(
+        dedent(
+            """
+            from task_cascadence.plugins import CronTask
+
+            class T2(CronTask):
+                name = "t2"
+
+                def run(self):
+                    return "t2"
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    class DummyLoader:
+        calls = 0
+
+        def __init__(self, base_url: str) -> None:
+            pass
+
+        def list_tasks(self):
+            type(self).calls += 1
+            if type(self).calls == 1:
+                return [{"id": "t1"}]
+            return [{"id": "t1"}, {"id": "t2"}]
+
+        def load_task(self, task_id: str):
+            if task_id == "t1":
+                return {"id": "t1", "path": "mod1:T1"}
+            if task_id == "t2":
+                return {"id": "t2", "path": "mod2:T2"}
+
+    monkeypatch.setenv("CRONYX_BASE_URL", "http://server")
+    monkeypatch.setenv("CASCADENCE_CRONYX_REFRESH", "1")
+    monkeypatch.setattr(
+        "task_cascadence.plugins.load_cronyx_plugins",
+        lambda url: None,
+    )
+    monkeypatch.setattr(
+        "task_cascadence.plugins.cronyx_server.CronyxServerLoader",
+        DummyLoader,
+    )
+
+    import task_cascadence
+
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+
+    sched = task_cascadence.scheduler.get_default_scheduler()
+    job = sched.scheduler.get_job("cronyx_refresh")
+    assert job is not None
+
+    names = [name for name, _ in sched.list_tasks()]
+    assert "t1" in names
+    assert "t2" not in names
+
+    job.func()
+
+    names = [name for name, _ in sched.list_tasks()]
+    assert "t1" in names
+    assert "t2" in names


### PR DESCRIPTION
## Summary
- configure scheduler to refresh Cronyx tasks periodically
- support `CASCADENCE_CRONYX_REFRESH` toggle
- clean up duplicate CLI imports
- test Cronyx refresh behaviour and config

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2aac54008326a2313b667e3140fb