### PR TITLE
Add user ID support for UME events

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -10,9 +10,6 @@ import click  # noqa: F401 - re-exported for CLI extensions
 
 import importlib
 import typer
-import importlib
-
-from .. import ume
 
 from ..scheduler import get_default_scheduler, default_scheduler
 
@@ -97,18 +94,22 @@ def list_tasks() -> None:
 def run_task(
     name: str,
     temporal: bool = typer.Option(False, "--temporal", help="Execute via Temporal"),
+    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
 ) -> None:
     """Run ``NAME`` if it exists and is enabled."""
 
     try:
-        get_default_scheduler().run_task(name, use_temporal=temporal)
+        get_default_scheduler().run_task(name, use_temporal=temporal, user_id=user_id)
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
 
 @app.command("trigger")
-def manual_trigger(name: str) -> None:
+def manual_trigger(
+    name: str,
+    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+) -> None:
     """Run ``NAME`` if it is a ManualTrigger task."""
 
     sched = get_default_scheduler()
@@ -116,7 +117,7 @@ def manual_trigger(name: str) -> None:
     if not task_info or not isinstance(task_info["task"], plugins.ManualTrigger):
         typer.echo(f"error: '{name}' is not a manual task", err=True)
         raise typer.Exit(code=1)
-    sched.run_task(name)
+    sched.run_task(name, user_id=user_id)
 
 
 

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -54,7 +54,11 @@ class BaseScheduler:
             yield name, info["disabled"]
 
     def run_task(
-        self, name: str, *, use_temporal: bool | None = None
+        self,
+        name: str,
+        *,
+        use_temporal: bool | None = None,
+        user_id: str | None = None,
     ) -> Any:
         """Run a task by name if it exists and is enabled."""
 
@@ -96,7 +100,7 @@ class BaseScheduler:
                     started_at=started,
                     finished_at=finished,
                 )
-                emit_task_run(run)
+                emit_task_run(run, user_id=user_id)
             return result
         raise AttributeError(f"Task '{name}' has no run() method")
 
@@ -171,7 +175,7 @@ class CronScheduler(BaseScheduler):
         with open(self.storage_path, "w") as fh:
             self._yaml.safe_dump(self.schedules, fh)
 
-    def _wrap_task(self, task):
+    def _wrap_task(self, task, user_id: str | None = None):
         @metrics.track_task
         def runner():
             from datetime import datetime
@@ -200,7 +204,7 @@ class CronScheduler(BaseScheduler):
                     started_at=started,
                     finished_at=finished,
                 )
-                emit_task_run(run)
+                emit_task_run(run, user_id=user_id)
 
         return runner
 


### PR DESCRIPTION
## Summary
- allow scheduler and cron wrappers to accept a user ID
- add `--user-id` option for CLI run and trigger commands
- include hashed user ID when emitting task run events
- test that hashed user IDs propagate through scheduler and CLI

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2aac14d48326b586d7f884dff8eb