### PR TITLE
Add schedules command

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -152,6 +152,16 @@ def schedule_task(name: str, expression: str) -> None:
         raise typer.Exit(code=1) from exc
 
 
+@app.command("schedules")
+def show_schedules() -> None:
+    """List configured cron schedules."""
+
+    sched = get_default_scheduler()
+    schedules = getattr(sched, "schedules", {})
+    for name, expr in schedules.items():
+        typer.echo(f"{name}\t{expr}")
+
+
 @app.command("replay-history")
 def replay_history(path: str) -> None:
     """Replay a workflow history from ``PATH``."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,4 +193,33 @@ def test_cli_run_user_id(monkeypatch):
     assert captured["run"].user_hash != "alice"
 
 
+def test_cli_schedules_lists_entries(monkeypatch, tmp_path):
+    from task_cascadence.scheduler import CronScheduler
+    from task_cascadence.plugins import ExampleTask
+
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    sched.register_task(ExampleTask(), "0 5 * * *")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedules"])
+
+    assert result.exit_code == 0
+    assert result.output == "ExampleTask\t0 5 * * *\n"
+
+
+def test_cli_schedules_empty(monkeypatch, tmp_path):
+    from task_cascadence.scheduler import CronScheduler
+
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedules"])
+
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
 


### PR DESCRIPTION
## Summary
- extend CLI with new `schedules` command
- test CLI schedules subcommand

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d30bc93408326a14595858a68158e