### PR TITLE
Add dev optional dependency section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,10 @@ dependencies = [
 
 [project.scripts]
 task = "task_cascadence.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "pytest",
+    "pytest-cov",
+]


### PR DESCRIPTION
## Summary
- expose optional dependency group `dev` with Ruff and pytest packages

## Testing
- `ruff check .`
- `pytest -q`
- `pip install --root-user-action=ignore -e .[dev]`

------
https://chatgpt.com/codex/tasks/task_e_687d4a9306a88326b885f3f11b7fa00a