### PR TITLE
Add secret-based user hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ plugin source for Python, Rust and Go lives in the ``examples/`` directory.
 See the [Go plugin README](examples/go_plugin/README.md) and
 [Rust plugin README](examples/rust_plugin/README.md) for build instructions.
 
+## Hashing User IDs
+
+User identifiers passed to emission helpers are hashed before transport.
+Provide a secret via the ``CASCADENCE_HASH_SECRET`` environment variable to
+salt these hashes, e.g. ``CASCADENCE_HASH_SECRET=abc123``. Omitting the
+variable hashes the plain ID.
+
 ## n8n Export
 
 Tasks registered with Cascadence can be exported as an n8n workflow using the

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -6,6 +6,7 @@ import threading
 import time
 from typing import Any
 import hashlib
+import os
 
 from ..transport import BaseTransport, get_client
 from .models import TaskRun, TaskSpec
@@ -15,7 +16,8 @@ _default_client: BaseTransport | None = None
 
 
 def _hash_user_id(user_id: str) -> str:
-    return hashlib.sha256(user_id.encode()).hexdigest()
+    secret = os.getenv("CASCADENCE_HASH_SECRET", "")
+    return hashlib.sha256((secret + user_id).encode()).hexdigest()
 
 
 def configure_transport(transport: str, **kwargs: Any) -> None:

--- a/tests/test_user_hash.py
+++ b/tests/test_user_hash.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from task_cascadence.ume import emit_task_spec, emit_task_run
+from task_cascadence.ume import emit_task_spec, emit_task_run, _hash_user_id
 from task_cascadence.ume.models import TaskSpec, TaskRun
 
 
@@ -35,4 +35,12 @@ def test_run_user_hash_not_raw():
     )
     emit_task_run(run, client, user_id="alice")
     assert client.events[0].user_hash != "alice"
+
+
+def test_hash_user_id_secret(monkeypatch):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "foo")
+    h1 = _hash_user_id("alice")
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "bar")
+    h2 = _hash_user_id("alice")
+    assert h1 != h2
 


### PR DESCRIPTION
## Summary
- hash `user_id` with optional `CASCADENCE_HASH_SECRET`
- test hashing secret logic
- document the environment variable in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4a8f7f008326b8bc719689654568