### PR TITLE
Improve register_task typing

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -145,7 +145,7 @@ def schedule_task(name: str, expression: str) -> None:
 
     try:
         task = task_info["task"]
-        sched.register_task(task, expression)
+        sched.register_task(name_or_task=task, task_or_expr=expression)
         typer.echo(f"{name} scheduled: {expression}")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -208,11 +208,23 @@ class CronScheduler(BaseScheduler):
 
         return runner
 
-    def register_task(self, arg1, arg2):
+    def register_task(
+        self,
+        name_or_task: str | BaseTask,
+        task_or_expr: BaseTask | str,
+    ) -> None:
         """Register a task with optional scheduling.
 
-        This method supports two calling styles for backwards
-        compatibility with :class:`BaseScheduler`:
+        Parameters
+        ----------
+        name_or_task:
+            Either a task name or the task instance.
+        task_or_expr:
+            Either the task instance (if ``name_or_task`` is a name) or a cron
+            expression used to schedule the task.
+
+        This method supports two calling styles for backwards compatibility
+        with :class:`BaseScheduler`:
 
         ``register_task(name, task)``
             Register ``task`` under ``name`` without scheduling.
@@ -221,13 +233,13 @@ class CronScheduler(BaseScheduler):
             Register ``task`` and schedule it using ``cron_expression``.
         """
 
-        if isinstance(arg1, str):
+        if isinstance(name_or_task, str):
             # Called with ``name`` and ``task``
-            name, task = arg1, arg2
+            name, task = name_or_task, task_or_expr
             super().register_task(name, task)
             return
 
-        task, cron_expression = arg1, arg2
+        task, cron_expression = name_or_task, task_or_expr
         job_id = task.__class__.__name__
         super().register_task(job_id, task)
         self.schedules[job_id] = cron_expression
@@ -242,7 +254,7 @@ class CronScheduler(BaseScheduler):
 
     def schedule_task(self, task: Any, cron_expression: str) -> None:
         """Convenience wrapper for :meth:`register_task`."""
-        self.register_task(task, cron_expression)
+        self.register_task(name_or_task=task, task_or_expr=cron_expression)
 
     def start(self):
         self.scheduler.start()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ class ManualTask(ManualTrigger):
 def test_manual_trigger_cli(monkeypatch):
     initialize()
     sched = get_default_scheduler()
-    sched.register_task("manual_demo", ManualTask())
+    sched.register_task(name_or_task="manual_demo", task_or_expr=ManualTask())
 
     from task_cascadence import ume
 
@@ -48,7 +48,7 @@ def test_run_command_temporal(monkeypatch):
     initialize()
     sched = get_default_scheduler()
     sched._temporal = backend
-    sched.register_task("dummy", DummyTask())
+    sched.register_task(name_or_task="dummy", task_or_expr=DummyTask())
 
     called = {}
 
@@ -103,7 +103,7 @@ def test_cli_schedule_creates_entry(monkeypatch, tmp_path):
 
     sched = CronScheduler(storage_path=tmp_path / "sched.yml")
     monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
-    sched.register_task("example", ExampleTask())
+    sched.register_task(name_or_task="example", task_or_expr=ExampleTask())
 
     runner = CliRunner()
     result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
@@ -229,7 +229,7 @@ def test_cli_transport_option_nats(monkeypatch):
 def test_cli_run_user_id(monkeypatch):
     initialize()
     sched = get_default_scheduler()
-    sched.register_task("manual_demo", ManualTask())
+    sched.register_task(name_or_task="manual_demo", task_or_expr=ManualTask())
 
     captured = {}
 
@@ -258,7 +258,7 @@ def test_cli_schedules_lists_entries(monkeypatch, tmp_path):
     sched = CronScheduler(storage_path=tmp_path / "sched.yml")
     monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
 
-    sched.register_task(ExampleTask(), "0 5 * * *")
+    sched.register_task(name_or_task=ExampleTask(), task_or_expr="0 5 * * *")
 
     runner = CliRunner()
     result = runner.invoke(app, ["schedules"])

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -16,7 +16,7 @@ def test_timezone_awareness(tmp_path):
     storage = tmp_path / "sched.yml"
     sched = CronScheduler(timezone="US/Pacific", storage_path=storage)
     task = DummyTask()
-    sched.register_task(task, "0 12 * * *")
+    sched.register_task(name_or_task=task, task_or_expr="0 12 * * *")
     job = sched.scheduler.get_job("DummyTask")
     from zoneinfo import ZoneInfo
 
@@ -28,7 +28,7 @@ def test_schedule_persistence(tmp_path):
     storage = tmp_path / "sched.yml"
     sched = CronScheduler(timezone="UTC", storage_path=storage)
     task = DummyTask()
-    sched.register_task(task, "*/5 * * * *")
+    sched.register_task(name_or_task=task, task_or_expr="*/5 * * * *")
     data = yaml.safe_load(storage.read_text())
     assert data["DummyTask"] == "*/5 * * * *"
 
@@ -49,7 +49,7 @@ def test_run_emits_result(monkeypatch, tmp_path):
     monkeypatch.setattr(ume, "emit_task_run", fake_emit)
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
-    sched.register_task(task, "*/1 * * * *")
+    sched.register_task(name_or_task=task, task_or_expr="*/1 * * * *")
     job = sched.scheduler.get_job("DummyTask")
     job.func()
     assert emitted_run is not None
@@ -62,7 +62,7 @@ def test_restore_schedules_on_init(tmp_path, monkeypatch):
     storage = tmp_path / "sched.yml"
     task = DummyTask()
     sched = CronScheduler(timezone="UTC", storage_path=storage)
-    sched.register_task(task, "*/5 * * * *")
+    sched.register_task(name_or_task=task, task_or_expr="*/5 * * * *")
 
     from task_cascadence import ume
 
@@ -104,7 +104,7 @@ def test_metrics_increment_for_job(tmp_path, monkeypatch):
     # Prevent actual event emission
     monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda run, user_id=None: None)
 
-    sched.register_task(task, "*/1 * * * *")
+    sched.register_task(name_or_task=task, task_or_expr="*/1 * * * *")
     job = sched.scheduler.get_job("DummyTask")
 
     success = metrics.TASK_SUCCESS.labels("runner")


### PR DESCRIPTION
## Summary
- provide clearer typing for CronScheduler.register_task
- update CLI scheduling logic
- update tests for new parameter names

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4a8f07748326aff81dd29a921346