### PR TITLE
Add cron scheduler validation in CLI

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -11,7 +11,11 @@ import click  # noqa: F401 - re-exported for CLI extensions
 import importlib
 import typer
 
-from ..scheduler import get_default_scheduler, default_scheduler
+from ..scheduler import (
+    get_default_scheduler,
+    default_scheduler,
+    CronScheduler,
+)
 
 from .. import plugins  # noqa: F401
 from ..metrics import start_metrics_server  # noqa: F401
@@ -138,6 +142,9 @@ def schedule_task(name: str, expression: str) -> None:
     """Schedule ``NAME`` according to ``EXPRESSION``."""
 
     sched = get_default_scheduler()
+    if not isinstance(sched, CronScheduler):
+        typer.echo("error: scheduler lacks cron capabilities", err=True)
+        raise typer.Exit(code=1)
     task_info = dict(sched._tasks).get(name)
     if not task_info:
         typer.echo(f"error: unknown task '{name}'", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,21 @@ def test_cli_schedule_unknown_task(monkeypatch):
     assert result.exit_code == 1
 
 
+def test_cli_schedule_requires_cron_scheduler(monkeypatch):
+    from task_cascadence.scheduler import BaseScheduler
+    from task_cascadence.plugins import ExampleTask
+
+    sched = BaseScheduler()
+    sched.register_task("example", ExampleTask())
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+
+    assert result.exit_code == 1
+    assert "scheduler lacks cron capabilities" in result.output
+
+
 def test_cli_replay_history(monkeypatch):
     backend = TemporalBackend()
     scheduler = BaseScheduler(temporal=backend)


### PR DESCRIPTION
## Summary
- ensure `task schedule` fails when the default scheduler isn't a `CronScheduler`
- cover new failure branch in CLI tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e43d9a50c8326bf18c637d635c010