### PR TITLE
Add optional name to metrics decorator

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -176,7 +176,7 @@ class CronScheduler(BaseScheduler):
             self._yaml.safe_dump(self.schedules, fh)
 
     def _wrap_task(self, task, user_id: str | None = None):
-        @metrics.track_task
+        @metrics.track_task(name=task.__class__.__name__)
         def runner():
             from datetime import datetime
             from uuid import uuid4

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -107,8 +107,8 @@ def test_metrics_increment_for_job(tmp_path, monkeypatch):
     sched.register_task(name_or_task=task, task_or_expr="*/1 * * * *")
     job = sched.scheduler.get_job("DummyTask")
 
-    success = metrics.TASK_SUCCESS.labels("runner")
-    failure = metrics.TASK_FAILURE.labels("runner")
+    success = metrics.TASK_SUCCESS.labels("DummyTask")
+    failure = metrics.TASK_FAILURE.labels("DummyTask")
 
     before_success = success._value.get()
     before_failure = failure._value.get()


### PR DESCRIPTION
## Summary
- allow `track_task` to take an optional name argument
- label scheduled jobs with their task class name
- adjust scheduler metrics test accordingly

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e43d8885083268303748d11db54c2