### PR TITLE
Start scheduler on initialize

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -45,6 +45,9 @@ def initialize() -> None:
             replace_existing=True,
         )
 
+    if hasattr(sched, "start"):
+        sched.start()
+
 
 from . import cli  # noqa: F401,E402
 

--- a/tests/test_initialize_scheduler.py
+++ b/tests/test_initialize_scheduler.py
@@ -1,0 +1,39 @@
+import importlib
+from task_cascadence.scheduler import CronScheduler
+from task_cascadence.plugins import CronTask
+
+
+def test_jobs_run_on_initialize(monkeypatch):
+    executed = []
+
+    class DummyTask(CronTask):
+        def run(self):
+            executed.append(1)
+
+    def fake_plugins_initialize():
+        from task_cascadence.scheduler import get_default_scheduler
+        sched = get_default_scheduler()
+        sched.register_task(name_or_task=DummyTask(), task_or_expr="* * * * *")
+
+    monkeypatch.setattr("task_cascadence.plugins.initialize", fake_plugins_initialize)
+    monkeypatch.setattr("task_cascadence.plugins.load_entrypoint_plugins", lambda: None)
+    monkeypatch.setattr("task_cascadence.plugins.load_cronyx_plugins", lambda url: None)
+    monkeypatch.setattr("task_cascadence.plugins.load_cronyx_tasks", lambda: None)
+
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda run, user_id=None: None)
+
+    start_called = {"val": False}
+
+    def fake_start(self):
+        start_called["val"] = True
+        for job in self.scheduler.get_jobs():
+            job.func()
+
+    monkeypatch.setattr(CronScheduler, "start", fake_start)
+
+    import task_cascadence
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+
+    assert start_called["val"]
+    assert executed


### PR DESCRIPTION
## Summary
- start the scheduler from `initialize()`
- test that CronScheduler jobs run when `initialize()` is executed

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e43d81260832681a39cd8c6a05f1e