### PR TITLE
Add PointerTask with UME pointer model

### DIFF
--- a/examples/python_plugin/pyplugin/__init__.py
+++ b/examples/python_plugin/pyplugin/__init__.py
@@ -1,7 +1,17 @@
-from task_cascadence.plugins import ManualTrigger
+from task_cascadence.plugins import ManualTrigger, PointerTask
 
 class DemoTask(ManualTrigger):
     name = "demo_python"
 
     def run(self):
         print("demo python task")
+
+
+class FamilyTask(PointerTask):
+    """Example task pointing to TaskRun IDs from different users."""
+
+    name = "family_pointer"
+
+    def run(self):
+        for ref in self.get_pointers():
+            print(f"pointer to {ref.run_id} for {ref.user_hash}")

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -11,6 +11,8 @@ import sys
 from importlib import metadata
 from typing import Dict
 
+from ..ume.models import TaskPointer
+
 
 from ..scheduler import get_default_scheduler
 
@@ -56,6 +58,21 @@ def register_webhook_task(cls: type[WebhookTask]) -> type[WebhookTask]:
 class ManualTrigger(BaseTask):
     """Base class for tasks triggered manually."""
     pass
+
+
+class PointerTask(BaseTask):
+    """Task referencing other users' task runs via pointers."""
+
+    def __init__(self) -> None:
+        self.pointers: list[TaskPointer] = []
+
+    def add_pointer(self, user_id: str, run_id: str) -> None:
+        from ..ume import _hash_user_id
+
+        self.pointers.append(TaskPointer(run_id=run_id, user_hash=_hash_user_id(user_id)))
+
+    def get_pointers(self) -> list[TaskPointer]:
+        return list(self.pointers)
 
 
 # ---------------------------------------------------------------------------

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -25,3 +25,11 @@ class TaskRun:
     started_at: datetime
     finished_at: datetime
     user_hash: Optional[str] = None
+
+
+@dataclass
+class TaskPointer:
+    """Reference to another user's task run."""
+
+    run_id: str
+    user_hash: str

--- a/tests/test_pointer_task.py
+++ b/tests/test_pointer_task.py
@@ -1,0 +1,15 @@
+from task_cascadence.plugins import PointerTask
+from task_cascadence.ume.models import TaskPointer
+
+
+def test_pointer_creation_and_retrieval(monkeypatch):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    task = PointerTask()
+    task.add_pointer("alice", "run1")
+    task.add_pointer("bob", "run2")
+
+    pointers = task.get_pointers()
+    assert [p.run_id for p in pointers] == ["run1", "run2"]
+    assert all(isinstance(p, TaskPointer) for p in pointers)
+    assert pointers[0].user_hash != "alice"
+    assert pointers[1].user_hash != "bob"


### PR DESCRIPTION
## Summary
- add `TaskPointer` dataclass to UME models
- implement `PointerTask` for referencing other users' task runs
- showcase `FamilyTask` in example Python plugin
- test pointer task creation and retrieval

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5072a0108326852b6014e98a8a11