### PR TITLE
Add scheduler running test & cleanup fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from task_cascadence import scheduler as scheduler_module
+
+
+@pytest.fixture(autouse=True)
+def shutdown_scheduler():
+    yield
+    sched = getattr(scheduler_module, "_default_scheduler", None)
+    if sched and hasattr(sched, "shutdown"):
+        try:
+            sched.shutdown(wait=False)
+        except Exception:
+            pass
+    scheduler_module._default_scheduler = None

--- a/tests/test_scheduler_running.py
+++ b/tests/test_scheduler_running.py
@@ -1,0 +1,11 @@
+import importlib
+
+import task_cascadence
+
+
+def test_scheduler_running_after_initialize():
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    sched = task_cascadence.scheduler.get_default_scheduler()
+    assert isinstance(sched, task_cascadence.scheduler.CronScheduler)
+    assert sched.scheduler.running


### PR DESCRIPTION
## Summary
- check CronScheduler starts after calling `initialize`
- shut down the default scheduler after each test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5073db20832692e8c75c3b133d88