### PR TITLE
Ensure TASK_SUCCESS label uses task name

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -84,7 +84,7 @@ class BaseScheduler:
 
             spec = TaskSpec(id=task.__class__.__name__, name=task.__class__.__name__)
 
-            @metrics.track_task
+            @metrics.track_task(name=task.__class__.__name__)
             def runner():
                 run_id = str(uuid4())
                 started = datetime.now()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -185,8 +185,8 @@ def test_run_task_metrics_success(monkeypatch):
     task = SimpleTask()
     sched.register_task("simple", task)
 
-    success = metrics.TASK_SUCCESS.labels("runner")
-    failure = metrics.TASK_FAILURE.labels("runner")
+    success = metrics.TASK_SUCCESS.labels("SimpleTask")
+    failure = metrics.TASK_FAILURE.labels("SimpleTask")
 
     before_success = success._value.get()
     before_failure = failure._value.get()
@@ -212,8 +212,8 @@ def test_run_task_metrics_failure(monkeypatch):
     task = BoomTask()
     sched.register_task("boom", task)
 
-    success = metrics.TASK_SUCCESS.labels("runner")
-    failure = metrics.TASK_FAILURE.labels("runner")
+    success = metrics.TASK_SUCCESS.labels("BoomTask")
+    failure = metrics.TASK_FAILURE.labels("BoomTask")
 
     before_success = success._value.get()
     before_failure = failure._value.get()


### PR DESCRIPTION
## Summary
- label metrics with the task's name when running tasks
- verify the labels are correct in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e50746aa883268b131547ca64b602