### PR TITLE
Add env-based test for scheduling restrictions

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,17 @@ def test_cli_schedule_requires_cron_scheduler(monkeypatch):
     assert result.exit_code == 1
     assert "scheduler lacks cron capabilities" in result.output
 
+def test_cli_schedule_env_base(monkeypatch):
+    """task schedule should fail without a cron scheduler"""
+    monkeypatch.setenv("CASCADENCE_SCHEDULER", "base")
+    import importlib
+    import task_cascadence
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+    assert result.exit_code == 1
+    assert "scheduler lacks cron capabilities" in result.output
 
 def test_cli_replay_history(monkeypatch):
     backend = TemporalBackend()


### PR DESCRIPTION
## Summary
- ensure `task schedule` warns when cron scheduling isn't available

## Testing
- `python -m ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5075df948326907f646c448916db