### PR TITLE
Handle unreachable Cronyx server

### DIFF
--- a/task_cascadence/plugins/cronyx_server.py
+++ b/task_cascadence/plugins/cronyx_server.py
@@ -1,6 +1,8 @@
 import os
 from typing import Any
 
+import requests
+
 from ..http_utils import request_with_retry
 
 
@@ -24,19 +26,23 @@ class CronyxServerLoader:
 
     def _get(self, path: str) -> Any:
         url = f"{self.base_url}{path}"
-        response = request_with_retry(
-            "GET",
-            url,
-            timeout=self.timeout,
-            retries=self.retries,
-            backoff_factor=self.backoff_factor,
-        )
+        try:
+            response = request_with_retry(
+                "GET",
+                url,
+                timeout=self.timeout,
+                retries=self.retries,
+                backoff_factor=self.backoff_factor,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            print(f"Failed to reach CronyxServer at {url}: {exc}")
+            return None
         return response.json()
 
     def list_tasks(self):
         """Return a list of available tasks."""
-        return self._get('/tasks')
+        return self._get('/tasks') or []
 
     def load_task(self, task_id: str):
         """Return a single task definition by ID."""
-        return self._get(f'/tasks/{task_id}')
+        return self._get(f'/tasks/{task_id}') or {}


### PR DESCRIPTION
## Summary
- make Cronyx server loader resilient to connection issues
- update loader tests for new behaviour and add coverage for connection errors

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9530592c8326a6ea8c0ade60ce80