### PR TITLE
Add user_id support for scheduled jobs

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -138,7 +138,11 @@ def disable_task(name: str) -> None:
 
 
 @app.command("schedule")
-def schedule_task(name: str, expression: str) -> None:
+def schedule_task(
+    name: str,
+    expression: str,
+    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+) -> None:
     """Schedule ``NAME`` according to ``EXPRESSION``."""
 
     sched = get_default_scheduler()
@@ -152,7 +156,9 @@ def schedule_task(name: str, expression: str) -> None:
 
     try:
         task = task_info["task"]
-        sched.register_task(name_or_task=task, task_or_expr=expression)
+        sched.register_task(
+            name_or_task=task, task_or_expr=expression, user_id=user_id
+        )
         typer.echo(f"{name} scheduled: {expression}")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,6 +113,27 @@ def test_cli_schedule_creates_entry(monkeypatch, tmp_path):
     assert data["ExampleTask"] == "0 12 * * *"
 
 
+def test_cli_schedule_user_id(monkeypatch, tmp_path):
+    from task_cascadence.scheduler import CronScheduler
+    from task_cascadence.plugins import ExampleTask
+    import yaml
+
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+    sched.register_task(name_or_task="example", task_or_expr=ExampleTask())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["schedule", "example", "0 12 * * *", "--user-id", "charlie"],
+    )
+
+    assert result.exit_code == 0
+    data = yaml.safe_load((tmp_path / "sched.yml").read_text())
+    assert data["ExampleTask"]["expr"] == "0 12 * * *"
+    assert data["ExampleTask"]["user_id"] == "charlie"
+
+
 def test_cli_schedule_unknown_task(monkeypatch):
     from task_cascadence.scheduler import CronScheduler
 


### PR DESCRIPTION
## Summary
- allow storing user IDs with scheduled jobs
- add CLI option to set schedule user ID
- ensure scheduler restores and records IDs correctly
- test schedule user ID handling

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f952f91448326be6cee8d8dc79f3b