### PR TITLE
Add asyncio transports and async emission

### DIFF
--- a/task_cascadence/transport.py
+++ b/task_cascadence/transport.py
@@ -13,6 +13,14 @@ class BaseTransport:
         raise NotImplementedError
 
 
+class AsyncBaseTransport:
+    """Abstract asynchronous transport client interface."""
+
+    async def enqueue(self, obj: Any, timeout: float = 0.2) -> None:
+        """Asynchronously send *obj* within ``timeout`` seconds."""
+        raise NotImplementedError
+
+
 class GrpcClient(BaseTransport):
     """gRPC transport client using a provided stub."""
 
@@ -37,18 +45,49 @@ class NatsClient(BaseTransport):
         self._connection.flush(timeout=timeout)
 
 
-def get_client(transport: str, **kwargs: Any) -> BaseTransport:
+class AsyncGrpcClient(AsyncBaseTransport):
+    """Asynchronous gRPC transport using an async stub."""
+
+    def __init__(self, stub: Any, method: str = "Send") -> None:
+        self._stub = stub
+        self._method = method
+
+    async def enqueue(self, obj: Any, timeout: float = 0.2) -> None:  # pragma: no cover - simple delegation
+        rpc = getattr(self._stub, self._method)
+        await rpc(obj, timeout=timeout)
+
+
+class AsyncNatsClient(AsyncBaseTransport):
+    """Asynchronous NATS transport using an async connection."""
+
+    def __init__(self, connection: Any, subject: str = "events") -> None:
+        self._connection = connection
+        self._subject = subject
+
+    async def enqueue(self, obj: Any, timeout: float = 0.2) -> None:  # pragma: no cover - simple delegation
+        await self._connection.publish(self._subject, obj)
+        await self._connection.flush(timeout=timeout)
+
+
+def get_client(transport: str, **kwargs: Any) -> BaseTransport | AsyncBaseTransport:
     """Return a transport client for ``transport``."""
     if transport == "grpc":
         return GrpcClient(**kwargs)
     if transport == "nats":
         return NatsClient(**kwargs)
+    if transport == "grpc_async":
+        return AsyncGrpcClient(**kwargs)
+    if transport == "nats_async":
+        return AsyncNatsClient(**kwargs)
     raise ValueError(f"Unknown transport type: {transport}")
 
 
 __all__ = [
     "BaseTransport",
+    "AsyncBaseTransport",
     "GrpcClient",
     "NatsClient",
+    "AsyncGrpcClient",
+    "AsyncNatsClient",
     "get_client",
 ]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,7 +1,13 @@
 import time
+import asyncio
 import pytest
 
-from task_cascadence.transport import GrpcClient, NatsClient
+from task_cascadence.transport import (
+    GrpcClient,
+    NatsClient,
+    AsyncGrpcClient,
+    AsyncNatsClient,
+)
 from task_cascadence.ume import emit_task_spec
 from task_cascadence.ume.models import TaskSpec
 
@@ -21,6 +27,21 @@ class SlowStub:
         time.sleep(0.3)
 
 
+class AsyncStub:
+    def __init__(self):
+        self.timeout = None
+        self.received = None
+
+    async def Send(self, msg, timeout=None):
+        self.timeout = timeout
+        self.received = msg
+
+
+class AsyncSlowStub:
+    async def Send(self, msg, timeout=None):
+        await asyncio.sleep(0.3)
+
+
 class FakeConn:
     def __init__(self):
         self.published = []
@@ -37,6 +58,24 @@ class SlowConn(FakeConn):
     def flush(self, timeout=0):
         time.sleep(0.3)
         super().flush(timeout)
+
+
+class AsyncConn:
+    def __init__(self):
+        self.published = []
+        self.flushed = None
+
+    async def publish(self, subject, msg):
+        self.published.append((subject, msg))
+
+    async def flush(self, timeout=0):
+        self.flushed = timeout
+
+
+class AsyncSlowConn(AsyncConn):
+    async def flush(self, timeout=0):
+        await asyncio.sleep(0.3)
+        await super().flush(timeout)
 
 
 def test_grpc_client_passes_timeout():
@@ -69,3 +108,53 @@ def test_nats_deadline_exceeded():
     spec = TaskSpec(id="2", name="nats")
     with pytest.raises(RuntimeError):
         emit_task_spec(spec, client=client)
+
+
+def test_async_grpc_client_passes_timeout():
+    stub = AsyncStub()
+    client = AsyncGrpcClient(stub)
+
+    async def run():
+        await client.enqueue("data", timeout=0.1)
+
+    asyncio.run(run())
+    assert stub.timeout == 0.1
+    assert stub.received == "data"
+
+
+def test_async_grpc_deadline_exceeded():
+    stub = AsyncSlowStub()
+    client = AsyncGrpcClient(stub)
+    spec = TaskSpec(id="3", name="ademo")
+
+    async def run():
+        task = emit_task_spec(spec, client=client, use_asyncio=True)
+        await task
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())
+
+
+def test_async_nats_client_passes_timeout():
+    conn = AsyncConn()
+    client = AsyncNatsClient(conn, subject="demo")
+
+    async def run():
+        await client.enqueue("msg", timeout=0.15)
+
+    asyncio.run(run())
+    assert conn.flushed == 0.15
+    assert conn.published == [("demo", "msg")]
+
+
+def test_async_nats_deadline_exceeded():
+    conn = AsyncSlowConn()
+    client = AsyncNatsClient(conn)
+    spec = TaskSpec(id="4", name="async-nats")
+
+    async def run():
+        task = emit_task_spec(spec, client=client, use_asyncio=True)
+        await task
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
- add AsyncBaseTransport with AsyncGrpcClient and AsyncNatsClient
- support async emission in emit_task_spec/run
- add async tests for transport clients and emit functions

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f991b50e08326b1ca7478f4c72726