### PR TITLE
Parse env vars via central loader

### DIFF
--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -34,5 +34,29 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     else:
         cfg["cronyx_refresh"] = bool(cfg.get("cronyx_refresh", True))
 
+    if "CRONYX_BASE_URL" in os.environ:
+        cfg["cronyx_base_url"] = os.environ["CRONYX_BASE_URL"]
+    if "CRONYX_TIMEOUT" in os.environ:
+        cfg["cronyx_timeout"] = float(os.environ["CRONYX_TIMEOUT"])
+
+    if "TEMPORAL_SERVER" in os.environ:
+        cfg["temporal_server"] = os.environ["TEMPORAL_SERVER"]
+
+    if "UME_TRANSPORT" in os.environ:
+        cfg["ume_transport"] = os.environ["UME_TRANSPORT"]
+    if "UME_GRPC_STUB" in os.environ:
+        cfg["ume_grpc_stub"] = os.environ["UME_GRPC_STUB"]
+    if "UME_GRPC_METHOD" in os.environ:
+        cfg["ume_grpc_method"] = os.environ["UME_GRPC_METHOD"]
+    if "UME_NATS_CONN" in os.environ:
+        cfg["ume_nats_conn"] = os.environ["UME_NATS_CONN"]
+    if "UME_NATS_SUBJECT" in os.environ:
+        cfg["ume_nats_subject"] = os.environ["UME_NATS_SUBJECT"]
+
+    if "CASCADENCE_HASH_SECRET" in os.environ:
+        cfg["hash_secret"] = os.environ["CASCADENCE_HASH_SECRET"]
+    else:
+        cfg.setdefault("hash_secret", "")
+
     return cfg
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -6,7 +6,6 @@ complex projects could load plugins dynamically using entry points.
 """
 
 import importlib
-import os
 import sys
 from importlib import metadata
 from typing import Dict
@@ -132,15 +131,20 @@ def initialize() -> None:
 
     load_entrypoint_plugins()
 
-    if "CRONYX_BASE_URL" in os.environ:
-        load_cronyx_plugins(os.environ["CRONYX_BASE_URL"])
+    from ..config import load_config
+
+    cfg = load_config()
+    if cfg.get("cronyx_base_url"):
+        load_cronyx_plugins(cfg["cronyx_base_url"])
 
 
 
 
 def load_cronyx_tasks() -> None:
     """Load tasks from a configured Cronyx server."""
-    url = os.getenv("CRONYX_BASE_URL")
+    from ..config import load_config
+
+    url = load_config().get("cronyx_base_url")
     if not url:
         return
     try:

--- a/task_cascadence/plugins/cronyx_server.py
+++ b/task_cascadence/plugins/cronyx_server.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 import requests
@@ -19,7 +18,10 @@ class CronyxServerLoader:
     ) -> None:
         self.base_url = base_url.rstrip("/")
         if timeout is None:
-            timeout = float(os.getenv("CRONYX_TIMEOUT", "5.0"))
+            from ..config import load_config
+
+            cfg_timeout = load_config().get("cronyx_timeout")
+            timeout = float(cfg_timeout if cfg_timeout is not None else 5.0)
         self.timeout = timeout
         self.retries = retries
         self.backoff_factor = backoff_factor

--- a/task_cascadence/temporal.py
+++ b/task_cascadence/temporal.py
@@ -12,7 +12,11 @@ from temporalio.worker import Replayer
 class TemporalBackend:
     """Thin wrapper around :class:`temporalio.client.Client`."""
 
-    def __init__(self, server: str = "localhost:7233") -> None:
+    def __init__(self, server: str | None = None) -> None:
+        if server is None:
+            from .config import load_config
+
+            server = load_config().get("temporal_server", "localhost:7233")
         self.server = server
         self._client: Optional[Client] = None
 

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -6,7 +6,7 @@ import threading
 import time
 from typing import Any
 import hashlib
-import os
+from ..config import load_config
 
 from ..transport import BaseTransport, get_client
 from .models import TaskRun, TaskSpec
@@ -16,7 +16,7 @@ _default_client: BaseTransport | None = None
 
 
 def _hash_user_id(user_id: str) -> str:
-    secret = os.getenv("CASCADENCE_HASH_SECRET", "")
+    secret = load_config().get("hash_secret", "")
     return hashlib.sha256((secret + user_id).encode()).hexdigest()
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,6 +4,7 @@ import os
 import task_cascadence
 from task_cascadence.scheduler import get_default_scheduler, BaseScheduler, CronScheduler
 from task_cascadence.scheduler import TemporalScheduler
+from task_cascadence.config import load_config
 
 
 def test_env_selects_base_scheduler(monkeypatch):
@@ -58,4 +59,27 @@ def test_yaml_temporal_scheduler(monkeypatch, tmp_path):
     importlib.reload(task_cascadence)
     task_cascadence.initialize()
     assert isinstance(get_default_scheduler(), TemporalScheduler)
+
+
+def test_env_parsed(monkeypatch):
+    monkeypatch.setenv("CRONYX_BASE_URL", "http://server")
+    monkeypatch.setenv("CRONYX_TIMEOUT", "7.5")
+    monkeypatch.setenv("TEMPORAL_SERVER", "remote:7233")
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.setenv("UME_GRPC_STUB", "pkg:stub")
+    monkeypatch.setenv("UME_GRPC_METHOD", "Foo")
+    monkeypatch.setenv("UME_NATS_CONN", "pkg:conn")
+    monkeypatch.setenv("UME_NATS_SUBJECT", "demo")
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+
+    cfg = load_config()
+    assert cfg["cronyx_base_url"] == "http://server"
+    assert cfg["cronyx_timeout"] == 7.5
+    assert cfg["temporal_server"] == "remote:7233"
+    assert cfg["ume_transport"] == "grpc"
+    assert cfg["ume_grpc_stub"] == "pkg:stub"
+    assert cfg["ume_grpc_method"] == "Foo"
+    assert cfg["ume_nats_conn"] == "pkg:conn"
+    assert cfg["ume_nats_subject"] == "demo"
+    assert cfg["hash_secret"] == "s"
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -78,3 +78,9 @@ def test_replay_uses_replayer(monkeypatch):
     backend.replay("history.json")
 
     replayer.replay.assert_called_once_with("history.json")
+
+
+def test_backend_server_from_env(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_SERVER", "remote:4444")
+    backend = TemporalBackend()
+    assert backend.server == "remote:4444"


### PR DESCRIPTION
## Summary
- handle Cronyx, Temporal and transport env vars in `load_config`
- use config loader instead of direct `os.getenv` access
- look up Temporal server and UME hash secret via config
- test that env vars are parsed and Temporal backend respects configuration

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f991af51c83268edd3969c6441658