### PR TITLE
Add test coverage for CLI transport validation

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,18 @@ def test_cli_transport_option(monkeypatch):
     }
 
 
+def test_cli_transport_missing_grpc_stub(monkeypatch):
+    """Missing --grpc-stub should cause an error for gRPC transport."""
+
+    initialize()
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--transport", "grpc", "list"])
+
+    assert result.exit_code == 2
+    assert "--grpc-stub is required for grpc transport" in result.stderr
+
+
 def test_cli_transport_option_nats(monkeypatch):
     """The CLI should support configuring the NATS transport."""
 
@@ -271,6 +283,30 @@ def test_cli_transport_option_nats(monkeypatch):
         "connection": dummy_nats_conn,
         "subject": "demo",
     }
+
+
+def test_cli_transport_missing_nats_conn(monkeypatch):
+    """Missing --nats-conn should raise an error for NATS transport."""
+
+    initialize()
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--transport", "nats", "list"])
+
+    assert result.exit_code == 2
+    assert "--nats-conn is required for nats transport" in result.stderr
+
+
+def test_cli_transport_unknown(monkeypatch):
+    """Unknown transport value should be rejected."""
+
+    initialize()
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--transport", "foo", "list"])
+
+    assert result.exit_code == 2
+    assert "Unknown transport: foo" in result.stderr
 
 
 def test_cli_run_user_id(monkeypatch):

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import pytest
 
 import task_cascadence
 from task_cascadence.scheduler import get_default_scheduler, BaseScheduler, CronScheduler
@@ -82,4 +83,16 @@ def test_env_parsed(monkeypatch):
     assert cfg["ume_nats_conn"] == "pkg:conn"
     assert cfg["ume_nats_subject"] == "demo"
     assert cfg["hash_secret"] == "s"
+
+
+def test_initialize_unknown_scheduler(monkeypatch):
+    """Providing an invalid scheduler should raise a ValueError."""
+
+    monkeypatch.setenv("CASCADENCE_SCHEDULER", "bogus")
+    import importlib
+    import task_cascadence
+
+    with pytest.raises(ValueError):
+        importlib.reload(task_cascadence)
+        task_cascadence.initialize()
 


### PR DESCRIPTION
## Summary
- add tests for missing/unknown transport options on the CLI
- check scheduler initialization with invalid backend

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9cba42448326b3446027e725c749