### PR TITLE
Add webhook task examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ scrape_configs:
 ``task webhook`` launches a FastAPI application that dispatches incoming
 events to any registered :class:`WebhookTask` implementations.
 
+Two built-in webhook tasks show how payloads from different services can be
+handled:
 
-The repository ships with a single ``example`` task to demonstrate the
+* ``GitHubWebhookTask`` extracts the ``action`` field from ``issues`` events.
+* ``CalComWebhookTask`` records the ``event`` name from Cal.com bookings.
+
+The repository also ships with a small ``example`` cron task to demonstrate the
 mechanics.
 
 The CLI's ``main`` function can also be called programmatically:

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -87,6 +87,36 @@ class ExampleTask(CronTask):
         print("Example task executed")
 
 
+@register_webhook_task
+class GitHubWebhookTask(WebhookTask):
+    """Example task parsing GitHub webhook events."""
+
+    events: list[str] = []
+
+    def handle_event(self, source: str, event_type: str, payload: dict) -> None:
+        """Record issue actions from GitHub events."""
+
+        if source == "github" and event_type == "issues":
+            action = payload.get("action")
+            if action:
+                self.__class__.events.append(action)
+
+
+@register_webhook_task
+class CalComWebhookTask(WebhookTask):
+    """Example task parsing Cal.com webhook events."""
+
+    events: list[str] = []
+
+    def handle_event(self, source: str, event_type: str, payload: dict) -> None:
+        """Record booking events from Cal.com."""
+
+        if source == "calcom" and event_type == "booking":
+            event = payload.get("event")
+            if event:
+                self.__class__.events.append(event)
+
+
 # ``registered_tasks`` is consumed by the scheduler during initialisation.
 registered_tasks: Dict[str, BaseTask] = {
     ExampleTask.name: ExampleTask(),

--- a/tests/test_builtin_webhook_tasks.py
+++ b/tests/test_builtin_webhook_tasks.py
@@ -1,0 +1,15 @@
+from task_cascadence.plugins import GitHubWebhookTask, CalComWebhookTask
+
+
+def test_github_webhook_task_parses_action():
+    GitHubWebhookTask.events.clear()
+    task = GitHubWebhookTask()
+    task.handle_event("github", "issues", {"action": "closed"})
+    assert GitHubWebhookTask.events == ["closed"]
+
+
+def test_calcom_webhook_task_parses_event():
+    CalComWebhookTask.events.clear()
+    task = CalComWebhookTask()
+    task.handle_event("calcom", "booking", {"event": "created"})
+    assert CalComWebhookTask.events == ["created"]


### PR DESCRIPTION
## Summary
- add `GitHubWebhookTask` and `CalComWebhookTask` examples
- document builtin webhook tasks in README
- test webhook payload parsing

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9cb90c208326b53b0f1ee4f3a8d3