### PR TITLE
Add pointer management CLI and persistence

### DIFF
--- a/task_cascadence/pointer_store.py
+++ b/task_cascadence/pointer_store.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Any, Dict, List
+
+import yaml
+
+from .ume import _hash_user_id
+
+
+class PointerStore:
+    """Persistent store for :class:`~task_cascadence.plugins.PointerTask` pointers."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_POINTERS_PATH")
+        if path is None:
+            path = Path.home() / ".cascadence" / "pointers.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: Dict[str, List[Dict[str, Any]]] = self._load()
+
+    def _load(self) -> Dict[str, List[Dict[str, Any]]]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or {}
+                if isinstance(data, dict):
+                    return data
+        return {}
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_pointer(self, task_name: str, user_id: str, run_id: str) -> None:
+        entry = {"run_id": run_id, "user_hash": _hash_user_id(user_id)}
+        self._data.setdefault(task_name, []).append(entry)
+        self._save()
+
+    def get_pointers(self, task_name: str) -> List[Dict[str, Any]]:
+        return list(self._data.get(task_name, []))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,4 +327,32 @@ def test_cli_schedules_empty(monkeypatch, tmp_path):
     assert result.output == ""
 
 
+def test_cli_pointer_add_and_list(monkeypatch, tmp_path):
+    from task_cascadence.scheduler import BaseScheduler
+    from task_cascadence.plugins import PointerTask
+    import yaml
+
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    store = tmp_path / "pointers.yml"
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(store))
+
+    class DemoPointer(PointerTask):
+        name = "demo_pointer"
+
+    sched = BaseScheduler()
+    task = DemoPointer()
+    sched.register_task("demo_pointer", task)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["pointer-add", "demo_pointer", "alice", "run1"])
+    assert result.exit_code == 0
+    assert task.get_pointers()[0].run_id == "run1"
+
+    result = runner.invoke(app, ["pointer-list", "demo_pointer"])
+    assert result.exit_code == 0
+    data = yaml.safe_load(store.read_text())
+    assert data["demo_pointer"][0]["run_id"] == "run1"
+
+
 


### PR DESCRIPTION
## Summary
- add `PointerStore` for persistent pointer tracking
- integrate `PointerTask` with the new store
- add `pointer-add` and `pointer-list` CLI commands
- test CLI pointer commands

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9cb7e24083268123fb45eee10106