### PR TITLE
Fix CronScheduler job replacement

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -195,7 +195,10 @@ class CronScheduler(BaseScheduler):
                 expr, timezone=self.scheduler.timezone
             )
             self.scheduler.add_job(
-                self._wrap_task(task, user_id=user_id), trigger=trigger, id=job_id
+                self._wrap_task(task, user_id=user_id),
+                trigger=trigger,
+                id=job_id,
+                replace_existing=True,
             )
 
     def _save_schedules(self):
@@ -281,7 +284,10 @@ class CronScheduler(BaseScheduler):
             cron_expression, timezone=self.scheduler.timezone
         )
         self.scheduler.add_job(
-            self._wrap_task(task, user_id=user_id), trigger=trigger, id=job_id
+            self._wrap_task(task, user_id=user_id),
+            trigger=trigger,
+            id=job_id,
+            replace_existing=True,
         )
 
     def schedule_task(


### PR DESCRIPTION
## Summary
- ensure CronScheduler replaces jobs if they already exist
- test that registering the same task twice while running updates the schedule

## Testing
- `ruff check .`
- `mypy task_cascadence`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3ba1ccc83268ee1097b20d718e2