### PR TITLE
Implement pointer synchronization via transport

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -260,6 +260,31 @@ def pointer_list(name: str) -> None:
         typer.echo(f"{entry['run_id']}\t{entry['user_hash']}")
 
 
+@app.command("pointer-send")
+def pointer_send(name: str, user_id: str, run_id: str) -> None:
+    """Publish a pointer update via the configured transport."""
+
+    from ..ume import emit_pointer_update, _hash_user_id
+    from ..ume.models import PointerUpdate
+
+    update = PointerUpdate(
+        task_name=name, run_id=run_id, user_hash=_hash_user_id(user_id)
+    )
+    emit_pointer_update(update)
+    typer.echo("pointer sent")
+
+
+@app.command("pointer-receive")
+def pointer_receive(name: str, run_id: str, user_hash: str) -> None:
+    """Store a received pointer update."""
+
+    store = PointerStore()
+    from ..ume.models import PointerUpdate
+
+    store.apply_update(PointerUpdate(task_name=name, run_id=run_id, user_hash=user_hash))
+    typer.echo("pointer stored")
+
+
 
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
@@ -285,5 +310,7 @@ __all__ = [
     "reload_plugins_cmd",
     "pointer_add",
     "pointer_list",
+    "pointer_send",
+    "pointer_receive",
 ]
 

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -10,7 +10,7 @@ import hashlib
 from ..config import load_config
 
 from ..transport import BaseTransport, AsyncBaseTransport, get_client
-from .models import TaskRun, TaskSpec
+from .models import TaskRun, TaskSpec, PointerUpdate
 
 
 _default_client: BaseTransport | AsyncBaseTransport | None = None
@@ -122,3 +122,21 @@ def emit_task_run(
             _async_queue_within_deadline(run, target)
         )
     return _queue_within_deadline(run, target)
+
+
+def emit_pointer_update(
+    update: PointerUpdate,
+    client: Any | None = None,
+    *,
+    use_asyncio: bool = False,
+) -> asyncio.Task | threading.Thread | None:
+    """Emit ``PointerUpdate`` using the configured transport."""
+
+    target = client or _default_client
+    if target is None:
+        raise ValueError("No transport client configured")
+    if use_asyncio:
+        return asyncio.get_running_loop().create_task(
+            _async_queue_within_deadline(update, target)
+        )
+    return _queue_within_deadline(update, target)

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -33,3 +33,12 @@ class TaskPointer:
 
     run_id: str
     user_hash: str
+
+
+@dataclass
+class PointerUpdate:
+    """Pointer synchronization message."""
+
+    task_name: str
+    run_id: str
+    user_hash: str

--- a/tests/test_pointer_sync.py
+++ b/tests/test_pointer_sync.py
@@ -1,0 +1,52 @@
+import yaml
+from typer.testing import CliRunner
+
+from task_cascadence.pointer_store import PointerStore
+from task_cascadence.cli import app
+from task_cascadence.ume.models import PointerUpdate
+
+
+def test_pointer_store_emits(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(tmp_path / "pointers.yml"))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    captured = {}
+
+    def fake_emit(update):
+        captured["update"] = update
+
+    monkeypatch.setattr(
+        "task_cascadence.pointer_store.emit_pointer_update", fake_emit
+    )
+
+    store = PointerStore()
+    store.add_pointer("demo", "alice", "run1")
+
+    assert isinstance(captured["update"], PointerUpdate)
+    assert captured["update"].task_name == "demo"
+    assert captured["update"].run_id == "run1"
+    assert captured["update"].user_hash != "alice"
+
+
+def test_cli_send_receive(monkeypatch, tmp_path):
+    store = tmp_path / "pointers.yml"
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(store))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    emitted = {}
+
+    def fake_emit(update):
+        emitted["update"] = update
+
+    monkeypatch.setattr("task_cascadence.ume.emit_pointer_update", fake_emit)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["pointer-send", "demo", "alice", "run1"])
+    assert result.exit_code == 0
+    user_hash = emitted["update"].user_hash
+    assert user_hash != "alice"
+
+    result = runner.invoke(app, ["pointer-receive", "demo", "run1", user_hash])
+    assert result.exit_code == 0
+
+    data = yaml.safe_load(store.read_text())
+    assert data["demo"][0]["run_id"] == "run1"
+    assert data["demo"][0]["user_hash"] == user_hash

--- a/tests/test_pointer_task.py
+++ b/tests/test_pointer_task.py
@@ -2,8 +2,9 @@ from task_cascadence.plugins import PointerTask
 from task_cascadence.ume.models import TaskPointer
 
 
-def test_pointer_creation_and_retrieval(monkeypatch):
+def test_pointer_creation_and_retrieval(monkeypatch, tmp_path):
     monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(tmp_path / "pointers.yml"))
     task = PointerTask()
     task.add_pointer("alice", "run1")
     task.add_pointer("bob", "run2")


### PR DESCRIPTION
## Summary
- send pointers via transport in `PointerStore`
- expose new CLI commands `pointer-send` and `pointer-receive`
- hash user ids before transport
- add `PointerUpdate` model and emit method
- test pointer synchronization logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb6699f348326acfe323b2b90e7c9