### PR TITLE
Add Cronyx scheduler backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ allows scheduled tasks to survive process restarts.
 
 ``task_cascadence.initialize`` reads configuration to decide which scheduler
 backend to instantiate. By default the cron-based scheduler is used. Set the
-``CASCADENCE_SCHEDULER`` environment variable to ``base`` or ``temporal`` or
-provide a YAML file via ``CASCADENCE_CONFIG`` containing::
+``CASCADENCE_SCHEDULER`` environment variable to ``base``, ``temporal`` or
+``cronyx`` or provide a YAML file via ``CASCADENCE_CONFIG`` containing::
 
     backend: temporal
 
 This selects the Temporal-based scheduler. ``backend: base`` chooses the simple
-in-memory scheduler instead.
+in-memory scheduler instead. ``backend: cronyx`` configures a
+``CronyxScheduler`` which forwards task execution to a running CronyxServer.
 
 
 ## Plugin Discovery
@@ -148,7 +149,7 @@ with the variables below. When set, they override values from the YAML file:
     Path to a YAML configuration file.
 
 ``CASCADENCE_SCHEDULER``
-    Select the scheduler backend (``cron``/``base``/``temporal``).
+    Select the scheduler backend (``cron``/``base``/``temporal``/``cronyx``).
 ``CASCADENCE_CRONYX_REFRESH``
     Disable Cronyx task refreshing when ``0`` or ``false``.
 ``CRONYX_BASE_URL``

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -13,6 +13,7 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
 
     The configuration currently supports selecting the scheduler backend via the
     ``backend`` key (``scheduler`` is accepted for backwards compatibility).
+    ``backend`` may be ``cron``, ``base``, ``temporal`` or ``cronyx``.
     Environment variable ``CASCADENCE_SCHEDULER`` overrides any value found in
     the YAML file. If no configuration is provided the scheduler defaults to
     ``cron``.

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -342,6 +342,9 @@ def create_scheduler(backend: str) -> BaseScheduler:
         return BaseScheduler()
     if backend == "temporal":
         return TemporalScheduler()
+    if backend == "cronyx":
+        from .cronyx import CronyxScheduler
+        return CronyxScheduler()
     raise ValueError(f"Unknown scheduler backend: {backend}")
 
 

--- a/task_cascadence/scheduler/cronyx.py
+++ b/task_cascadence/scheduler/cronyx.py
@@ -1,0 +1,69 @@
+"""Scheduler communicating with a CronyxServer instance."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..http_utils import request_with_retry
+from . import BaseScheduler
+
+
+class CronyxScheduler(BaseScheduler):
+    """Run and schedule tasks via a remote CronyxServer."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        timeout: float | None = None,
+        retries: int = 3,
+        backoff_factor: float = 0.5,
+    ) -> None:
+        super().__init__()
+        from ..config import load_config
+
+        cfg = load_config()
+        self.base_url = (base_url or cfg.get("cronyx_base_url", "")).rstrip("/")
+        if not self.base_url:
+            raise ValueError("CronyxScheduler requires cronyx_base_url")
+        if timeout is None:
+            cfg_timeout = cfg.get("cronyx_timeout")
+            timeout = float(cfg_timeout if cfg_timeout is not None else 5.0)
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff_factor = backoff_factor
+
+    def _request(self, method: str, path: str, json: Any | None = None) -> Any:
+        url = f"{self.base_url}{path}"
+        response = request_with_retry(
+            method,
+            url,
+            timeout=self.timeout,
+            retries=self.retries,
+            backoff_factor=self.backoff_factor,
+            json=json,
+        )
+        return response.json()
+
+    def run_task(
+        self,
+        name: str,
+        *,
+        use_temporal: bool | None = None,
+        user_id: str | None = None,
+    ) -> Any:
+        if name in self._tasks and not self._tasks[name]["disabled"]:
+            return super().run_task(name, use_temporal=use_temporal, user_id=user_id)
+        payload = {"task": name}
+        if user_id is not None:
+            payload["user_id"] = user_id
+        data = self._request("POST", "/jobs", json=payload)
+        return data.get("result")
+
+    def schedule_task(
+        self, name: str, cron_expression: str, *, user_id: str | None = None
+    ) -> Any:
+        payload = {"task": name, "cron": cron_expression}
+        if user_id is not None:
+            payload["user_id"] = user_id
+        return self._request("POST", "/jobs", json=payload)

--- a/tests/test_cronyx_scheduler.py
+++ b/tests/test_cronyx_scheduler.py
@@ -1,0 +1,72 @@
+import importlib
+import os
+import requests
+
+import task_cascadence
+from task_cascadence.scheduler.cronyx import CronyxScheduler
+from task_cascadence.scheduler import create_scheduler
+
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.data
+
+
+def test_run_task_posts_job(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, timeout=0, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return DummyResp({"result": "ok"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    sched = CronyxScheduler(base_url="http://server")
+    result = sched.run_task("demo", user_id="bob")
+    assert result == "ok"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://server/jobs"
+    assert captured["json"] == {"task": "demo", "user_id": "bob"}
+
+
+def test_schedule_task_posts_job(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, timeout=0, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return DummyResp({"scheduled": True})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    sched = CronyxScheduler(base_url="http://server")
+    resp = sched.schedule_task("demo", "* * * * *", user_id="alice")
+    assert resp == {"scheduled": True}
+    assert captured["json"] == {"task": "demo", "cron": "* * * * *", "user_id": "alice"}
+
+
+def test_create_scheduler_factory():
+    os.environ["CRONYX_BASE_URL"] = "http://server"
+    sched = create_scheduler("cronyx")
+    os.environ.pop("CRONYX_BASE_URL")
+    assert isinstance(sched, CronyxScheduler)
+
+
+def test_env_selects_cronyx(monkeypatch):
+    monkeypatch.setenv("CASCADENCE_SCHEDULER", "cronyx")
+    monkeypatch.setenv("CRONYX_BASE_URL", "http://server")
+    monkeypatch.setattr(task_cascadence.plugins, "initialize", lambda: None)
+    monkeypatch.setattr(task_cascadence.plugins, "load_cronyx_tasks", lambda: None)
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    from task_cascadence.scheduler import get_default_scheduler
+
+    assert isinstance(get_default_scheduler(), CronyxScheduler)
+


### PR DESCRIPTION
## Summary
- implement `CronyxScheduler` that talks to CronyxServer job API
- allow `backend: cronyx` in configuration
- document Cronyx backend in README
- add unit tests for CronyxScheduler

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb61f7ba08326b215b0f182eadd2b