### PR TITLE
Use logger in CronyxServerLoader

### DIFF
--- a/task_cascadence/plugins/cronyx_server.py
+++ b/task_cascadence/plugins/cronyx_server.py
@@ -1,8 +1,11 @@
 from typing import Any
 
+import logging
 import requests
 
 from ..http_utils import request_with_retry
+
+logger = logging.getLogger(__name__)
 
 
 class CronyxServerLoader:
@@ -37,7 +40,7 @@ class CronyxServerLoader:
                 backoff_factor=self.backoff_factor,
             )
         except (requests.ConnectionError, requests.Timeout) as exc:
-            print(f"Failed to reach CronyxServer at {url}: {exc}")
+            logger.warning("Failed to reach CronyxServer at %s: %s", url, exc)
             return None
         return response.json()
 


### PR DESCRIPTION
## Summary
- add a module level `logger` in `cronyx_server.py`
- log connection failures with `logger.warning`
- verify logging output in `test_loader_connection_error`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d4b5c59c8326b32bbed9c1a483bd