### PR TITLE
Add orchestrator TaskPipeline

### DIFF
--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -1,0 +1,86 @@
+"""Task orchestration pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from .ume import emit_task_spec, emit_task_run
+from .ume.models import TaskRun, TaskSpec
+
+
+@dataclass
+class TaskPipeline:
+    """Orchestrate a task through multiple stages.
+
+    Each stage emits an event via :mod:`task_cascadence.ume`.
+    """
+
+    task: Any
+
+    def _emit_stage(self, stage: str, user_id: str | None = None) -> None:
+        spec = TaskSpec(
+            id=self.task.__class__.__name__,
+            name=self.task.__class__.__name__,
+            description=stage,
+        )
+        emit_task_spec(spec, user_id=user_id)
+
+    def intake(self, *, user_id: str | None = None) -> None:
+        if hasattr(self.task, "intake"):
+            self.task.intake()
+        self._emit_stage("intake", user_id)
+
+    def plan(self, *, user_id: str | None = None) -> Any:
+        plan_result = None
+        if hasattr(self.task, "plan"):
+            plan_result = self.task.plan()
+        self._emit_stage("planning", user_id)
+        return plan_result
+
+    def execute(self, plan_result: Any = None, *, user_id: str | None = None) -> Any:
+        start_ts = Timestamp()
+        start_ts.FromDatetime(datetime.now())
+        status = "success"
+        try:
+            result = self._call_run(plan_result)
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            end_ts = Timestamp()
+            end_ts.FromDatetime(datetime.now())
+            run = TaskRun(
+                spec=TaskSpec(
+                    id=self.task.__class__.__name__,
+                    name=self.task.__class__.__name__,
+                ),
+                run_id=str(uuid4()),
+                status=status,
+                started_at=start_ts,
+                finished_at=end_ts,
+            )
+            emit_task_run(run, user_id=user_id)
+        return result
+
+    def verify(self, exec_result: Any = None, *, user_id: str | None = None) -> Any:
+        verify_result = exec_result
+        if hasattr(self.task, "verify"):
+            verify_result = self.task.verify(exec_result)
+        self._emit_stage("verification", user_id)
+        return verify_result
+
+    # ------------------------------------------------------------------
+    def run(self, *, user_id: str | None = None) -> Any:
+        self.intake(user_id=user_id)
+        plan_result = self.plan(user_id=user_id)
+        exec_result = self.execute(plan_result, user_id=user_id)
+        return self.verify(exec_result, user_id=user_id)
+
+    def _call_run(self, plan_result: Any) -> Any:
+        """Execute the task's ``run`` method."""
+        return self.task.run()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,75 @@
+from task_cascadence.orchestrator import TaskPipeline
+from task_cascadence.ume import _hash_user_id
+
+
+class DemoTask:
+    def __init__(self, steps):
+        self.steps = steps
+
+    def intake(self):
+        self.steps.append("intake")
+
+    def plan(self):
+        self.steps.append("plan")
+        return "plan"
+
+    def run(self):
+        self.steps.append("run")
+        return "result"
+
+    def verify(self, result):
+        self.steps.append(f"verify:{result}")
+        return "ok"
+
+
+def test_pipeline_emits_events(monkeypatch):
+    steps = []
+    emitted = []
+
+    def fake_spec(spec, user_id=None):
+        if user_id is not None:
+            spec.user_hash = _hash_user_id(user_id)
+        emitted.append(("spec", spec.description, spec.user_hash))
+
+    def fake_run(run, user_id=None):
+        if user_id is not None:
+            run.user_hash = _hash_user_id(user_id)
+        emitted.append(("run", run.status, run.user_hash))
+
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", fake_spec)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", fake_run)
+
+    task = DemoTask(steps)
+    pipeline = TaskPipeline(task)
+
+    result = pipeline.run(user_id="bob")
+
+    assert result == "ok"
+    assert steps == ["intake", "plan", "run", "verify:result"]
+    stages = [e[0] for e in emitted]
+    assert stages == ["spec", "spec", "run", "spec"]
+    assert emitted[0][2] == _hash_user_id("bob")
+    assert emitted[2][2] == _hash_user_id("bob")
+
+
+def test_pipeline_without_optional(monkeypatch):
+    emitted = []
+
+    def fake_spec(spec, user_id=None):
+        emitted.append(spec.description)
+
+    def fake_run(run, user_id=None):
+        emitted.append("run")
+
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", fake_spec)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", fake_run)
+
+    class Simple:
+        def run(self):
+            return "done"
+
+    pipeline = TaskPipeline(Simple())
+    result = pipeline.run()
+
+    assert result == "done"
+    assert emitted == ["intake", "planning", "run", "verification"]


### PR DESCRIPTION
## Summary
- implement `TaskPipeline` class to orchestrate tasks
- emit UME events during intake, planning, execution and verification
- add unit tests for the new pipeline

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881620066ac83269028b6f39de61d3d