### PR TITLE
Add pause/resume task support

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -142,6 +142,30 @@ def disable_task(name: str) -> None:
         raise typer.Exit(code=1) from exc
 
 
+@app.command("pause")
+def pause_task(name: str) -> None:
+    """Pause ``NAME`` so it temporarily stops running."""
+
+    try:
+        get_default_scheduler().pause_task(name)
+        typer.echo(f"{name} paused")
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@app.command("resume")
+def resume_task(name: str) -> None:
+    """Resume a paused task called ``NAME``."""
+
+    try:
+        get_default_scheduler().resume_task(name)
+        typer.echo(f"{name} resumed")
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
 @app.command("schedule")
 def schedule_task(
     name: str,

--- a/task_cascadence/scheduler/cronyx.py
+++ b/task_cascadence/scheduler/cronyx.py
@@ -52,7 +52,11 @@ class CronyxScheduler(BaseScheduler):
         use_temporal: bool | None = None,
         user_id: str | None = None,
     ) -> Any:
-        if name in self._tasks and not self._tasks[name]["disabled"]:
+        if (
+            name in self._tasks
+            and not self._tasks[name]["disabled"]
+            and not self._tasks[name].get("paused")
+        ):
             return super().run_task(name, use_temporal=use_temporal, user_id=user_id)
         payload = {"task": name}
         if user_id is not None:

--- a/task_cascadence/scheduler/dag.py
+++ b/task_cascadence/scheduler/dag.py
@@ -126,6 +126,9 @@ class DagCronScheduler(CronScheduler):
 
     def _wrap_task(self, task: Any, user_id: str | None = None):
         def runner():
+            info = self._tasks.get(task.__class__.__name__)
+            if info and info.get("paused"):
+                return
             self.run_task(task.__class__.__name__, user_id=user_id)
 
         return runner

--- a/tests/test_cli_pause.py
+++ b/tests/test_cli_pause.py
@@ -1,0 +1,43 @@
+from typer.testing import CliRunner
+
+from task_cascadence.cli import app
+from task_cascadence.scheduler import BaseScheduler, CronScheduler
+from task_cascadence.plugins import ExampleTask, CronTask
+
+
+def test_cli_pause_resume(monkeypatch):
+    sched = BaseScheduler()
+    task = ExampleTask()
+    sched.register_task("example", task)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["pause", "example"])
+    assert result.exit_code == 0
+    assert sched._tasks["example"]["paused"] is True
+
+    result = runner.invoke(app, ["resume", "example"])
+    assert result.exit_code == 0
+    assert sched._tasks["example"]["paused"] is False
+
+
+class DummyTask(CronTask):
+    def __init__(self):
+        self.count = 0
+
+    def run(self):
+        self.count += 1
+
+
+def test_paused_job_does_not_run(monkeypatch, tmp_path):
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    task = DummyTask()
+    sched.register_task(name_or_task=task, task_or_expr="* * * * *")
+    sched.pause_task("DummyTask")
+
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda run, user_id=None: None)
+
+    job = sched.scheduler.get_job("DummyTask")
+    job.func()
+
+    assert task.count == 0


### PR DESCRIPTION
## Summary
- add `task pause` and `task resume` commands
- support pausing and resuming in scheduler classes
- ensure CronyxScheduler respects paused tasks
- test paused CLI commands and scheduler behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688161ffc91c8326a335800a4cff222e