### PR TITLE
Implement pipeline stage event storage

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -107,9 +107,14 @@ def run_task(
 ) -> None:
     """Run ``NAME`` if it exists and is enabled."""
 
+    from ..ume import emit_stage_update
+
     try:
+        emit_stage_update(name, "start", user_id=user_id)
         get_default_scheduler().run_task(name, use_temporal=temporal, user_id=user_id)
+        emit_stage_update(name, "finish", user_id=user_id)
     except Exception as exc:  # pragma: no cover - simple error propagation
+        emit_stage_update(name, "error", user_id=user_id)
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from .ume import emit_task_spec, emit_task_run
+from .ume import emit_task_spec, emit_task_run, emit_stage_update
 from .ume.models import TaskRun, TaskSpec
 
 
@@ -29,6 +29,7 @@ class TaskPipeline:
             description=stage,
         )
         emit_task_spec(spec, user_id=user_id)
+        emit_stage_update(self.task.__class__.__name__, stage, user_id=user_id)
 
     def intake(self, *, user_id: str | None = None) -> None:
         if hasattr(self.task, "intake"):
@@ -48,6 +49,7 @@ class TaskPipeline:
         status = "success"
         try:
             result = self._call_run(plan_result)
+            emit_stage_update(self.task.__class__.__name__, "run", user_id=user_id)
         except Exception:
             status = "error"
             raise

--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Any, Dict, List
+
+import yaml
+
+
+class StageStore:
+    """Persistent store for pipeline stage events."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_STAGES_PATH")
+        if path is None:
+            path = Path.home() / ".cascadence" / "stages.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: Dict[str, List[Dict[str, Any]]] = self._load()
+
+    def _load(self) -> Dict[str, List[Dict[str, Any]]]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or {}
+                if isinstance(data, dict):
+                    return data
+        return {}
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_event(self, task_name: str, stage: str, user_hash: str | None) -> None:
+        entry: Dict[str, Any] = {"stage": stage}
+        if user_hash is not None:
+            entry["user_hash"] = user_hash
+        events = self._data.setdefault(task_name, [])
+        events.append(entry)
+        self._save()
+
+    def get_events(self, task_name: str) -> List[Dict[str, Any]]:
+        return list(self._data.get(task_name, []))

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -1,0 +1,73 @@
+import yaml
+from typer.testing import CliRunner
+
+from task_cascadence.orchestrator import TaskPipeline
+from task_cascadence.cli import app
+from task_cascadence.scheduler import BaseScheduler
+from task_cascadence.plugins import ExampleTask
+from task_cascadence.ume import _hash_user_id
+
+
+class DemoTask:
+    def intake(self):
+        pass
+
+    def plan(self):
+        return None
+
+    def run(self):
+        return "ok"
+
+    def verify(self, result):
+        return result
+
+
+def test_pipeline_stage_events(monkeypatch, tmp_path):
+    path = tmp_path / "stages.yml"
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(path))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+
+    monkeypatch.setattr(
+        "task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None
+    )
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    pipeline = TaskPipeline(DemoTask())
+    pipeline.run(user_id="alice")
+
+    data = yaml.safe_load(path.read_text())
+    events = data["DemoTask"]
+    stages = [e["stage"] for e in events]
+    assert stages == ["intake", "planning", "run", "verification"]
+    for e in events:
+        assert e["user_hash"] == _hash_user_id("alice")
+
+
+def test_cli_stage_events(monkeypatch, tmp_path):
+    path = tmp_path / "stages.yml"
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(path))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+
+    sched = BaseScheduler()
+    sched.register_task("example", ExampleTask())
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    monkeypatch.setattr(
+        "task_cascadence.ume.emit_task_run", lambda *a, **k: None
+    )
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "example", "--user-id", "bob"])
+    assert result.exit_code == 0
+
+    data = yaml.safe_load(path.read_text())
+    events = data["example"]
+    assert events[0]["stage"] == "start"
+    assert events[-1]["stage"] == "finish"
+    assert events[0]["user_hash"] == _hash_user_id("bob")


### PR DESCRIPTION
## Summary
- add `StageStore` for persisting pipeline stage events
- support stage updates in UME helpers
- emit stage updates from orchestrator and CLI
- test stage event recording

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688168d749f48326a03770a1806e0f05