### PR TITLE
Add research step with optional tino_storm support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "types-requests",
     "types-PyYAML",
 ]
+research = [
+    "tino_storm",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -13,6 +13,7 @@ from . import plugins  # noqa: F401
 from . import ume  # noqa: F401
 from . import metrics  # noqa: F401
 from . import temporal  # noqa: F401
+from . import research  # noqa: F401
 from .config import load_config
 from apscheduler.triggers.cron import CronTrigger
 
@@ -57,6 +58,7 @@ __all__ = [
     "api",
     "metrics",
     "temporal",
+    "research",
     "initialize",
     "create_scheduler",
     "TemporalScheduler",

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -11,6 +11,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 from .ume import emit_task_spec, emit_task_run
 from .ume.models import TaskRun, TaskSpec
+from . import research
 
 
 @dataclass
@@ -34,6 +35,15 @@ class TaskPipeline:
         if hasattr(self.task, "intake"):
             self.task.intake()
         self._emit_stage("intake", user_id)
+
+    def research(self, *, user_id: str | None = None) -> Any:
+        """Perform optional research for the task."""
+        if hasattr(self.task, "research"):
+            query = self.task.research()
+            result = research.gather(query)
+            self._emit_stage("research", user_id)
+            return result
+        return None
 
     def plan(self, *, user_id: str | None = None) -> Any:
         plan_result = None
@@ -77,6 +87,7 @@ class TaskPipeline:
     # ------------------------------------------------------------------
     def run(self, *, user_id: str | None = None) -> Any:
         self.intake(user_id=user_id)
+        self.research(user_id=user_id)
         plan_result = self.plan(user_id=user_id)
         exec_result = self.execute(plan_result, user_id=user_id)
         return self.verify(exec_result, user_id=user_id)

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -14,12 +14,17 @@ class _ReloadHandler(FileSystemEventHandler):
 
     def __init__(self) -> None:
         self._last: tuple[str | None, float] = (None, 0.0)
+        self._ignore = True
 
     def on_any_event(self, event):  # pragma: no cover - simple passthrough
         if event.is_directory:
             return
 
         now = time.monotonic()
+        if self._ignore:
+            self._ignore = False
+            self._last = (event.src_path, now)
+            return
         path, last = self._last
         if event.src_path == path and now - last < 1:
             return

--- a/task_cascadence/research.py
+++ b/task_cascadence/research.py
@@ -1,0 +1,24 @@
+"""Helpers for task research using the optional ``tino_storm`` package."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    import tino_storm  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may be missing
+    tino_storm = None  # type: ignore
+
+
+def gather(query: str) -> Any:
+    """Return research information for ``query`` using ``tino_storm``."""
+    if tino_storm is None:  # pragma: no cover - runtime behaviour
+        raise RuntimeError("tino_storm is not installed")
+
+    if hasattr(tino_storm, "search"):
+        return tino_storm.search(query)
+
+    if callable(tino_storm):
+        return tino_storm(query)
+
+    raise RuntimeError("Unsupported tino_storm interface")

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,43 @@
+from task_cascadence.orchestrator import TaskPipeline
+
+
+def test_pipeline_research(monkeypatch):
+    steps = []
+    emitted = []
+
+    def fake_spec(spec, user_id=None):
+        emitted.append(spec.description)
+
+    def fake_run(run, user_id=None):
+        emitted.append("run")
+
+    def fake_gather(query: str):
+        steps.append(f"research:{query}")
+        return "info"
+
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", fake_spec)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", fake_run)
+    monkeypatch.setattr("task_cascadence.research.gather", fake_gather)
+
+    class ResearchTask:
+        def research(self):
+            return "foo"
+
+        def plan(self):
+            steps.append("plan")
+            return "plan"
+
+        def run(self):
+            steps.append("run")
+            return "result"
+
+        def verify(self, result):
+            steps.append(f"verify:{result}")
+            return "ok"
+
+    pipeline = TaskPipeline(ResearchTask())
+    result = pipeline.run()
+
+    assert result == "ok"
+    assert steps == ["research:foo", "plan", "run", "verify:result"]
+    assert emitted == ["intake", "research", "planning", "run", "verification"]


### PR DESCRIPTION
## Summary
- add optional `tino_storm` extra
- expose new `research` helper
- update `TaskPipeline` to run optional research step
- ignore first event in plugin watcher to avoid spurious reloads
- test research integration

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688168d6aaac8326a18dc834703670a5