### PR TITLE
Add basic FastAPI dashboard

### DIFF
--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ..scheduler import get_default_scheduler
+from ..stage_store import StageStore
+
+app = FastAPI()
+
+
+def _get_stage(store: StageStore, task_name: str) -> str | None:
+    events = store.get_events(task_name)
+    return events[-1]["stage"] if events else None
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(request: Request) -> HTMLResponse:
+    store = StageStore()
+    sched = get_default_scheduler()
+    rows = []
+    for name, info in sched._tasks.items():
+        stage = _get_stage(store, name)
+        paused = info.get("paused", False)
+        button = (
+            f"<form method='post' action='/resume/{name}'>"
+            "<button type='submit'>Resume</button></form>"
+            if paused
+            else (
+                f"<form method='post' action='/pause/{name}'>"
+                "<button type='submit'>Pause</button></form>"
+            )
+        )
+        status = "paused" if paused else "running"
+        rows.append(
+            f"<tr><td>{name}</td><td>{stage or ''}</td><td>{status}</td><td>{button}</td></tr>"
+        )
+    body = """
+    <html><body>
+    <h1>Cascadence Dashboard</h1>
+    <table>
+    <tr><th>Task</th><th>Stage</th><th>Status</th><th>Control</th></tr>
+    {rows}
+    </table>
+    </body></html>
+    """.format(rows="\n".join(rows))
+    return HTMLResponse(body)
+
+
+@app.post("/pause/{name}")
+def pause(name: str) -> RedirectResponse:
+    sched = get_default_scheduler()
+    sched.pause_task(name)
+    return RedirectResponse("/", status_code=303)
+
+
+@app.post("/resume/{name}")
+def resume(name: str) -> RedirectResponse:
+    sched = get_default_scheduler()
+    sched.resume_task(name)
+    return RedirectResponse("/", status_code=303)
+
+
+__all__ = ["app", "dashboard", "pause", "resume"]

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -14,16 +14,14 @@ class _ReloadHandler(FileSystemEventHandler):
 
     def __init__(self) -> None:
         self._last: tuple[str | None, float] = (None, 0.0)
-        self._ignore = True
+        self._start = time.monotonic()
 
     def on_any_event(self, event):  # pragma: no cover - simple passthrough
         if event.is_directory:
             return
 
         now = time.monotonic()
-        if self._ignore:
-            self._ignore = False
-            self._last = (event.src_path, now)
+        if now - self._start < 0.5:
             return
         path, last = self._last
         if event.src_path == path and now - last < 1:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+
+from task_cascadence.dashboard import app, StageStore
+from task_cascadence.scheduler import BaseScheduler
+from task_cascadence.plugins import ExampleTask
+
+
+def setup(monkeypatch, tmp_path):
+    sched = BaseScheduler()
+    task = ExampleTask()
+    sched.register_task("example", task)
+    monkeypatch.setattr(
+        "task_cascadence.dashboard.get_default_scheduler", lambda: sched
+    )
+    store = StageStore(path=tmp_path / "stages.yml")
+    monkeypatch.setattr("task_cascadence.dashboard.StageStore", lambda: store)
+    return sched, store
+
+
+def test_dashboard_index(monkeypatch, tmp_path):
+    sched, store = setup(monkeypatch, tmp_path)
+    store.add_event("example", "run", None)
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "example" in resp.text
+    assert "run" in resp.text
+
+
+def test_pause_resume(monkeypatch, tmp_path):
+    sched, _ = setup(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post("/pause/example", follow_redirects=False)
+    assert resp.status_code == 303
+    assert sched._tasks["example"]["paused"] is True
+    resp = client.post("/resume/example", follow_redirects=False)
+    assert resp.status_code == 303
+    assert sched._tasks["example"]["paused"] is False


### PR DESCRIPTION
## Summary
- add simple FastAPI dashboard app for showing active pipelines
- allow pausing and resuming via dashboard
- adjust PluginWatcher to handle startup events reliably
- include tests for dashboard endpoints

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881703b52f083269413949706cc26fc