### PR TITLE
Implement pause/resume API

### DIFF
--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -45,6 +45,8 @@ class PluginWatcher:
         """Start watching the directory."""
         self._observer.schedule(self._handler, str(self.path), recursive=True)
         self._observer.start()
+        # Ensure the first modification triggers a reload when using polling
+        self._handler._ignore = False
 
     def stop(self) -> None:
         """Stop watching."""

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -1,0 +1,40 @@
+from fastapi.testclient import TestClient
+
+from task_cascadence.api import app
+from task_cascadence.scheduler import BaseScheduler
+from task_cascadence.plugins import ExampleTask
+from task_cascadence.stage_store import StageStore
+
+
+def setup_scheduler(monkeypatch):
+    sched = BaseScheduler()
+    task = ExampleTask()
+    sched.register_task("example", task)
+    monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
+    return sched
+
+
+def test_api_pause_resume(monkeypatch):
+    sched = setup_scheduler(monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post("/tasks/example/pause")
+    assert resp.status_code == 200
+    assert sched._tasks["example"]["paused"] is True
+
+    resp = client.post("/tasks/example/resume")
+    assert resp.status_code == 200
+    assert sched._tasks["example"]["paused"] is False
+
+
+def test_api_pipeline_status(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+    StageStore().add_event("example", "start", None)
+    StageStore().add_event("example", "finish", None)
+
+    setup_scheduler(monkeypatch)
+    client = TestClient(app)
+
+    resp = client.get("/pipeline/example")
+    assert resp.status_code == 200
+    assert resp.json() == [{"stage": "start"}, {"stage": "finish"}]


### PR DESCRIPTION
## Summary
- expose pause, resume and pipeline status REST endpoints
- surface orchestrator pause/resume features via the API
- add regression tests for new endpoints
- tweak plugin watcher so polling reloads correctly

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881703ac53c8326a75e6b262f85107c