### PR TITLE
Add orchestrated mod setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ and Cascadence will fetch and register any advertised tasks on startup. Example
 plugin source for Python, Rust and Go lives in the ``examples/`` directory.
 See the [Go plugin README](examples/go_plugin/README.md) and
 [Rust plugin README](examples/rust_plugin/README.md) for build instructions.
+The ``examples/orchestrated_mod_setup.py`` script demonstrates a staged mod
+installation workflow that can be paused and resumed.
 
 To try the Python demo plugin install it in editable mode and list the
 available tasks:

--- a/examples/orchestrated_mod_setup.py
+++ b/examples/orchestrated_mod_setup.py
@@ -1,0 +1,55 @@
+"""Example demonstrating staged mod installation with pause/resume."""
+
+from task_cascadence.scheduler.dag import DagCronScheduler
+from task_cascadence.plugins import CronTask
+from task_cascadence.ume import emit_stage_update
+
+
+class DownloadMod(CronTask):
+    name = "DownloadMod"
+
+    def run(self) -> None:
+        print("Downloading mod archive")
+        emit_stage_update("mod_setup", "download")
+
+
+class InstallMod(CronTask):
+    name = "InstallMod"
+
+    def run(self) -> None:
+        print("Installing mod")
+        emit_stage_update("mod_setup", "install")
+
+
+class EnableMod(CronTask):
+    name = "EnableMod"
+
+    def run(self) -> None:
+        print("Enabling mod")
+        emit_stage_update("mod_setup", "enable")
+
+
+def main() -> None:
+    sched = DagCronScheduler(timezone="UTC")
+    sched.register_task(DownloadMod(), "* * * * *")
+    sched.register_task(InstallMod(), "* * * * *", dependencies=["DownloadMod"]) \
+        # run after download
+    sched.register_task(EnableMod(), "* * * * *", dependencies=["InstallMod"])  # final step
+
+    # Run the full pipeline once
+    sched.run_task("EnableMod")
+
+    # Pause the install stage
+    sched.pause_task("InstallMod")
+    try:
+        sched.run_task("EnableMod")
+    except ValueError as exc:
+        print(f"Pipeline halted: {exc}")
+
+    # Resume the stage and finish the pipeline
+    sched.resume_task("InstallMod")
+    sched.run_task("EnableMod")
+
+
+if __name__ == "__main__":
+    main()

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -10,13 +10,13 @@ from . import reload_plugins
 
 
 class _ReloadHandler(FileSystemEventHandler):
-    """Internal handler that reloads plugins on any file change."""
+    """Internal handler that reloads plugins on file modifications."""
 
     def __init__(self) -> None:
         self._last: tuple[str | None, float] = (None, 0.0)
         self._start = time.monotonic()
 
-    def on_any_event(self, event):  # pragma: no cover - simple passthrough
+    def on_modified(self, event):  # pragma: no cover - simple passthrough
         if event.is_directory:
             return
 


### PR DESCRIPTION
## Summary
- add `orchestrated_mod_setup.py` example showing staged mod installation with pause/resume
- refine plugin watcher to trigger reload only on modifications
- mention the new example in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688176385ffc8326a8bd0f835b95a480