### PR TITLE
Add stage events for pause/resume

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -331,6 +331,22 @@ class CronScheduler(BaseScheduler):
     def list_jobs(self):
         return self.scheduler.get_jobs()
 
+    def pause_task(self, name: str) -> None:
+        """Pause ``name`` and emit a stage event."""
+
+        super().pause_task(name)
+        from ..ume import emit_stage_update
+
+        emit_stage_update(name, "paused")
+
+    def resume_task(self, name: str) -> None:
+        """Resume ``name`` and emit a stage event."""
+
+        super().resume_task(name)
+        from ..ume import emit_stage_update
+
+        emit_stage_update(name, "resumed")
+
 
 # ---------------------------------------------------------------------------
 # Default scheduler accessor

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -1,30 +1,38 @@
 from fastapi.testclient import TestClient
 
 from task_cascadence.api import app
-from task_cascadence.scheduler import BaseScheduler
+from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.stage_store import StageStore
 
 
-def setup_scheduler(monkeypatch):
-    sched = BaseScheduler()
+def setup_scheduler(monkeypatch, tmp_path):
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
     task = ExampleTask()
     sched.register_task("example", task)
     monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
     return sched
 
 
-def test_api_pause_resume(monkeypatch):
-    sched = setup_scheduler(monkeypatch)
+def test_api_pause_resume(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    sched = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
 
     resp = client.post("/tasks/example/pause")
     assert resp.status_code == 200
     assert sched._tasks["example"]["paused"] is True
+    events = StageStore(path=tmp_path / "stages.yml").get_events("example")
+    assert events[-1]["stage"] == "paused"
 
     resp = client.post("/tasks/example/resume")
     assert resp.status_code == 200
     assert sched._tasks["example"]["paused"] is False
+    events = StageStore(path=tmp_path / "stages.yml").get_events("example")
+    assert events[-1]["stage"] == "resumed"
 
 
 def test_api_pipeline_status(monkeypatch, tmp_path):
@@ -32,7 +40,7 @@ def test_api_pipeline_status(monkeypatch, tmp_path):
     StageStore().add_event("example", "start", None)
     StageStore().add_event("example", "finish", None)
 
-    setup_scheduler(monkeypatch)
+    setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
 
     resp = client.get("/pipeline/example")


### PR DESCRIPTION
## Summary
- emit stage updates when pausing/resuming with `CronScheduler`
- test CLI pause/resume persists stage events
- test API pause/resume persists stage events

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688181cceb3483268725c81ec08a2745