### PR TITLE
Add timestamp tracking for StageStore events

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,11 +20,13 @@ def setup(monkeypatch, tmp_path):
 def test_dashboard_index(monkeypatch, tmp_path):
     sched, store = setup(monkeypatch, tmp_path)
     store.add_event("example", "run", None)
+    ts = store.get_events("example")[0]["time"]
     client = TestClient(app)
     resp = client.get("/")
     assert resp.status_code == 200
     assert "example" in resp.text
     assert "run" in resp.text
+    assert ts in resp.text
 
 
 def test_pause_resume(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- include ISO timestamps in `StageStore.add_event`
- normalise legacy entries when loading the stage store
- show the timestamp on the dashboard
- expect timestamps from `/pipeline/{name}` endpoint
- test the timestamp behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881845c08a88326b1b060e175472f5d