### PR TITLE
Add pointer-sync CLI command

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -314,6 +314,15 @@ def pointer_receive(name: str, run_id: str, user_hash: str) -> None:
     typer.echo("pointer stored")
 
 
+@app.command("pointer-sync")
+def pointer_sync_cmd() -> None:
+    """Start the pointer synchronization service."""
+
+    from .. import pointer_sync
+
+    pointer_sync.run()
+
+
 
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
@@ -341,5 +350,6 @@ __all__ = [
     "pointer_list",
     "pointer_send",
     "pointer_receive",
+    "pointer_sync_cmd",
 ]
 

--- a/tests/test_pointer_sync_service.py
+++ b/tests/test_pointer_sync_service.py
@@ -1,7 +1,9 @@
 import yaml
 import importlib
+from typer.testing import CliRunner
 
 from task_cascadence import pointer_sync
+from task_cascadence.cli import app
 
 
 def test_pointer_sync_grpc(monkeypatch, tmp_path):
@@ -55,5 +57,62 @@ conn = Conn()
 
     data = yaml.safe_load(store.read_text())
     assert data["demo"] == [{"run_id": "r2", "user_hash": "x"}]
+
+
+def test_cli_pointer_sync_grpc(monkeypatch, tmp_path):
+    store = tmp_path / "pointers.yml"
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(store))
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.setenv("UME_GRPC_METHOD", "Subscribe")
+
+    module = tmp_path / "stub_cli.py"
+    module.write_text(
+        """
+class Stub:
+    @staticmethod
+    def Subscribe():
+        from task_cascadence.ume.protos.tasks_pb2 import PointerUpdate
+        return [PointerUpdate(task_name='demo', run_id='cli1', user_hash='u')]
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_GRPC_STUB", "stub_cli:Stub")
+
+    importlib.invalidate_caches()
+    runner = CliRunner()
+    result = runner.invoke(app, ["pointer-sync"])
+    assert result.exit_code == 0
+
+    data = yaml.safe_load(store.read_text())
+    assert data["demo"] == [{"run_id": "cli1", "user_hash": "u"}]
+
+
+def test_cli_pointer_sync_nats(monkeypatch, tmp_path):
+    store = tmp_path / "pointers.yml"
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(store))
+    monkeypatch.setenv("UME_TRANSPORT", "nats")
+
+    module = tmp_path / "conn_cli.py"
+    module.write_text(
+        """
+class Conn:
+    def subscribe_sync(self, subject):
+        from task_cascadence.ume.protos.tasks_pb2 import PointerUpdate
+        update = PointerUpdate(task_name='demo', run_id='cli2', user_hash='x')
+        return [update.SerializeToString()]
+conn = Conn()
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_NATS_CONN", "conn_cli:conn")
+    monkeypatch.setenv("UME_NATS_SUBJECT", "events")
+
+    importlib.invalidate_caches()
+    runner = CliRunner()
+    result = runner.invoke(app, ["pointer-sync"])
+    assert result.exit_code == 0
+
+    data = yaml.safe_load(store.read_text())
+    assert data["demo"] == [{"run_id": "cli2", "user_hash": "x"}]
 
 


### PR DESCRIPTION
## Summary
- add pointer-sync command to CLI
- test that CLI service consumes gRPC/NATS events

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881845b7bc48326850e0f5a523c09a0