### PR TITLE
Add async research handling

### DIFF
--- a/task_cascadence/research.py
+++ b/task_cascadence/research.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+import inspect
 
 try:
     import tino_storm  # type: ignore
@@ -22,3 +23,23 @@ def gather(query: str) -> Any:
         return tino_storm(query)
 
     raise RuntimeError("Unsupported tino_storm interface")
+
+
+async def async_gather(query: str) -> Any:
+    """Asynchronously return research information for ``query`` using ``tino_storm``.
+
+    If the call to ``tino_storm`` returns a coroutine it will be awaited.
+    """
+    if tino_storm is None:  # pragma: no cover - runtime behaviour
+        raise RuntimeError("tino_storm is not installed")
+
+    if hasattr(tino_storm, "search"):
+        result = tino_storm.search(query)
+    elif callable(tino_storm):
+        result = tino_storm(query)
+    else:
+        raise RuntimeError("Unsupported tino_storm interface")
+
+    if inspect.isawaitable(result):
+        return await result
+    return result


### PR DESCRIPTION
## Summary
- support async research helper via new `async_gather`
- handle async context in `TaskPipeline.research`
- cover sync and async research flows

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688190e581c083268d9b4be0869a356e