### PR TITLE
Add config path tests

### DIFF
--- a/task_cascadence/pointer_store.py
+++ b/task_cascadence/pointer_store.py
@@ -8,6 +8,7 @@ import yaml
 
 from .ume import _hash_user_id, emit_pointer_update
 from .ume.models import PointerUpdate
+from .config import load_config
 
 
 class PointerStore:
@@ -16,6 +17,9 @@ class PointerStore:
     def __init__(self, path: str | Path | None = None) -> None:
         if path is None:
             path = os.getenv("CASCADENCE_POINTERS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("pointers_path")
         if path is None:
             path = Path.home() / ".cascadence" / "pointers.yml"
         self.path = Path(path)

--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 
 import yaml
 
+from .config import load_config
+
 
 class StageStore:
     """Persistent store for pipeline stage events."""
@@ -14,6 +16,9 @@ class StageStore:
     def __init__(self, path: str | Path | None = None) -> None:
         if path is None:
             path = os.getenv("CASCADENCE_STAGES_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("stages_path")
         if path is None:
             path = Path.home() / ".cascadence" / "stages.yml"
         self.path = Path(path)

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -1,0 +1,23 @@
+import yaml
+from task_cascadence.config import load_config
+from task_cascadence.stage_store import StageStore
+from task_cascadence.pointer_store import PointerStore
+
+
+def test_config_paths(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    stages = tmp_path / "stages.yml"
+    pointers = tmp_path / "pointers.yml"
+    cfg.write_text(yaml.safe_dump({"stages_path": str(stages), "pointers_path": str(pointers)}))
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
+    monkeypatch.delenv("CASCADENCE_POINTERS_PATH", raising=False)
+    monkeypatch.delenv("CASCADENCE_STAGES_PATH", raising=False)
+
+    cfg_data = load_config()
+    assert cfg_data["stages_path"] == str(stages)
+    assert cfg_data["pointers_path"] == str(pointers)
+
+    s_store = StageStore()
+    p_store = PointerStore()
+    assert s_store.path == stages
+    assert p_store.path == pointers


### PR DESCRIPTION
## Summary
- add config paths test ensuring StageStore and PointerStore read YAML values
- allow StageStore and PointerStore to use `stages_path` and `pointers_path` from config

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688287c91b8483268df9c2a46cff53dc