### PR TITLE
Add config defaults for stage and pointer stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,13 @@ with the variables below. When set, they override values from the YAML file:
     NATS subject for event publishing.
 ``CASCADENCE_HASH_SECRET``
     Salt used when hashing user identifiers.
+``CASCADENCE_STAGES_PATH``
+    Location of the ``stages.yml`` file used by :class:`StageStore`.
+``CASCADENCE_POINTERS_PATH``
+    Location of the ``pointers.yml`` file used by :class:`PointerStore`.
+
+The YAML configuration may also define ``stages_path`` and ``pointers_path``
+to override these defaults.
 
 Example ``cascadence.yml`` enabling gRPC transport and research support:
 
@@ -311,6 +318,8 @@ ume_transport: grpc
 ume_grpc_stub: myproject.rpc:Stub
 ume_grpc_method: Send
 hash_secret: supersecret
+stages_path: /tmp/stages.yml
+pointers_path: /tmp/pointers.yml
 ```
 
 Install ``tino_storm`` to allow tasks to perform research queries during the

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -59,5 +59,15 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     else:
         cfg.setdefault("hash_secret", "")
 
+    if "CASCADENCE_STAGES_PATH" in os.environ:
+        cfg["stages_path"] = os.environ["CASCADENCE_STAGES_PATH"]
+    elif "stages_path" in cfg:
+        cfg["stages_path"] = cfg["stages_path"]
+
+    if "CASCADENCE_POINTERS_PATH" in os.environ:
+        cfg["pointers_path"] = os.environ["CASCADENCE_POINTERS_PATH"]
+    elif "pointers_path" in cfg:
+        cfg["pointers_path"] = cfg["pointers_path"]
+
     return cfg
 

--- a/task_cascadence/pointer_store.py
+++ b/task_cascadence/pointer_store.py
@@ -8,6 +8,7 @@ import yaml
 
 from .ume import _hash_user_id, emit_pointer_update
 from .ume.models import PointerUpdate
+from .config import load_config
 
 
 class PointerStore:
@@ -16,6 +17,9 @@ class PointerStore:
     def __init__(self, path: str | Path | None = None) -> None:
         if path is None:
             path = os.getenv("CASCADENCE_POINTERS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("pointers_path")
         if path is None:
             path = Path.home() / ".cascadence" / "pointers.yml"
         self.path = Path(path)

--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 
 import yaml
 
+from .config import load_config
+
 
 class StageStore:
     """Persistent store for pipeline stage events."""
@@ -14,6 +16,9 @@ class StageStore:
     def __init__(self, path: str | Path | None = None) -> None:
         if path is None:
             path = os.getenv("CASCADENCE_STAGES_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("stages_path")
         if path is None:
             path = Path.home() / ".cascadence" / "stages.yml"
         self.path = Path(path)


### PR DESCRIPTION
## Summary
- parse `stages_path` and `pointers_path` in `load_config`
- use those config values as defaults in `StageStore` and `PointerStore`
- document the new options in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688287c8d1508326b35a339984485f56