### PR TITLE
Add pointer endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ httpx.post("http://localhost:8000/tasks/example/run", headers={"X-User-ID": "bob
 Including the ``X-User-ID`` header attaches a hashed identifier to emitted
 events, aligning with the project's privacy goals.
 
+Pointers for :class:`PointerTask` implementations can be managed via the API as well:
+
+```python
+httpx.post(
+    "http://localhost:8000/pointers/family_pointer",
+    params={"user_id": "alice", "run_id": "run42"},
+)
+httpx.get("http://localhost:8000/pointers/family_pointer").json()
+httpx.post(
+    "http://localhost:8000/pointers/family_pointer/receive",
+    params={"run_id": "xyz", "user_hash": "abc"},
+)
+```
+
 ## Dashboard
 
 Launch the web dashboard with:

--- a/tests/test_api_pointers.py
+++ b/tests/test_api_pointers.py
@@ -1,0 +1,50 @@
+from task_cascadence.api import app
+from task_cascadence.scheduler import BaseScheduler
+from task_cascadence.plugins import PointerTask
+from task_cascadence.ume import _hash_user_id
+from fastapi.testclient import TestClient
+import tempfile
+import yaml
+
+class DemoPointer(PointerTask):
+    name = "demo_pointer"
+
+
+def setup_scheduler(monkeypatch):
+    sched = BaseScheduler()
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", tmp.name)
+    task = DemoPointer()
+    sched.register_task("demo_pointer", task)
+    monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+    return sched, task, tmp.name
+
+
+def test_pointer_add_and_list(monkeypatch):
+    sched, task, store = setup_scheduler(monkeypatch)
+    client = TestClient(app)
+    resp = client.post("/pointers/demo_pointer", params={"user_id": "alice", "run_id": "r1"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "added"}
+
+    resp = client.get("/pointers/demo_pointer")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == [{"run_id": "r1", "user_hash": _hash_user_id("alice")}] 
+    assert task.get_pointers()[0].run_id == "r1"
+
+
+def test_pointer_receive(monkeypatch):
+    sched, task, store_path = setup_scheduler(monkeypatch)
+    client = TestClient(app)
+    user_hash = _hash_user_id("bob")
+    resp = client.post(
+        "/pointers/demo_pointer/receive",
+        params={"run_id": "r2", "user_hash": user_hash},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "stored"}
+
+    data = yaml.safe_load(open(store_path).read())
+    assert data["demo_pointer"] == [{"run_id": "r2", "user_hash": user_hash}]


### PR DESCRIPTION
## Summary
- expose pointer add/list/receive via FastAPI
- reuse CLI pointer logic for API routes
- document pointer management API
- test pointer endpoints

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882907e12e08326947091f39bc89e68