### PR TITLE
Add pointer counts to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ uvicorn task_cascadence.dashboard:app
 ```
 
 Navigate to ``http://localhost:8000`` to see task statuses and pause or resume
-individual tasks.
+individual tasks. The table also lists the number of pointers stored for each
+task via ``PointerStore``.
 
 ## Schedule Persistence
 

--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from ..scheduler import get_default_scheduler
 from ..stage_store import StageStore
+from ..pointer_store import PointerStore
 
 app = FastAPI()
 
@@ -17,6 +18,7 @@ def _get_event(store: StageStore, task_name: str) -> dict | None:
 @app.get("/", response_class=HTMLResponse)
 def dashboard(request: Request) -> HTMLResponse:
     store = StageStore()
+    p_store = PointerStore()
     sched = get_default_scheduler()
     rows = []
     for name, info in sched._tasks.items():
@@ -24,6 +26,7 @@ def dashboard(request: Request) -> HTMLResponse:
         stage = event["stage"] if event else None
         ts = event.get("time") if event else None
         paused = info.get("paused", False)
+        ptrs = len(p_store.get_pointers(name))
         button = (
             f"<form method='post' action='/resume/{name}'>"
             "<button type='submit'>Resume</button></form>"
@@ -35,13 +38,13 @@ def dashboard(request: Request) -> HTMLResponse:
         )
         status = "paused" if paused else "running"
         rows.append(
-            f"<tr><td>{name}</td><td>{stage or ''}</td><td>{ts or ''}</td><td>{status}</td><td>{button}</td></tr>"
+            f"<tr><td>{name}</td><td>{stage or ''}</td><td>{ts or ''}</td><td>{status}</td><td>{ptrs}</td><td>{button}</td></tr>"
         )
     body = """
     <html><body>
     <h1>Cascadence Dashboard</h1>
     <table>
-    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Control</th></tr>
+    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Pointers</th><th>Control</th></tr>
     {rows}
     </table>
     </body></html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from task_cascadence.dashboard import app, StageStore
+from task_cascadence.dashboard import app, StageStore, PointerStore
 from task_cascadence.scheduler import BaseScheduler
 from task_cascadence.plugins import ExampleTask
 
@@ -12,25 +12,29 @@ def setup(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "task_cascadence.dashboard.get_default_scheduler", lambda: sched
     )
-    store = StageStore(path=tmp_path / "stages.yml")
-    monkeypatch.setattr("task_cascadence.dashboard.StageStore", lambda: store)
-    return sched, store
+    stage_store = StageStore(path=tmp_path / "stages.yml")
+    pointer_store = PointerStore(path=tmp_path / "pointers.yml")
+    monkeypatch.setattr("task_cascadence.dashboard.StageStore", lambda: stage_store)
+    monkeypatch.setattr("task_cascadence.dashboard.PointerStore", lambda: pointer_store)
+    return sched, stage_store, pointer_store
 
 
 def test_dashboard_index(monkeypatch, tmp_path):
-    sched, store = setup(monkeypatch, tmp_path)
-    store.add_event("example", "run", None)
-    ts = store.get_events("example")[0]["time"]
+    sched, s_store, p_store = setup(monkeypatch, tmp_path)
+    s_store.add_event("example", "run", None)
+    p_store.add_pointer("example", "alice", "r1")
+    ts = s_store.get_events("example")[0]["time"]
     client = TestClient(app)
     resp = client.get("/")
     assert resp.status_code == 200
     assert "example" in resp.text
     assert "run" in resp.text
     assert ts in resp.text
+    assert "<td>1</td>" in resp.text
 
 
 def test_pause_resume(monkeypatch, tmp_path):
-    sched, _ = setup(monkeypatch, tmp_path)
+    sched, _, _ = setup(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.post("/pause/example", follow_redirects=False)
     assert resp.status_code == 303


### PR DESCRIPTION
## Summary
- display pointer counts in the web dashboard
- show the count next to task status
- test dashboard pointer count rendering
- document pointer counts in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829ad79a4c83269d100ca6c663238f