### PR TITLE
Add pointer count display to dashboard

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -5,10 +5,6 @@ from fastapi import FastAPI, Depends, HTTPException, Header
 from ..scheduler import get_default_scheduler, CronScheduler
 from ..stage_store import StageStore
 from ..cli import _pointer_add, _pointer_list, _pointer_receive
-from ..pointer_store import PointerStore
-from ..plugins import PointerTask
-from ..ume import emit_pointer_update, _hash_user_id
-from ..ume.models import PointerUpdate
 
 app = FastAPI()
 

--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from ..scheduler import get_default_scheduler
 from ..stage_store import StageStore
+from ..pointer_store import PointerStore
 
 app = FastAPI()
 
@@ -17,12 +18,14 @@ def _get_event(store: StageStore, task_name: str) -> dict | None:
 @app.get("/", response_class=HTMLResponse)
 def dashboard(request: Request) -> HTMLResponse:
     store = StageStore()
+    pointers = PointerStore()
     sched = get_default_scheduler()
     rows = []
     for name, info in sched._tasks.items():
         event = _get_event(store, name)
         stage = event["stage"] if event else None
         ts = event.get("time") if event else None
+        pointer_count = len(pointers.get_pointers(name))
         paused = info.get("paused", False)
         button = (
             f"<form method='post' action='/resume/{name}'>"
@@ -35,13 +38,20 @@ def dashboard(request: Request) -> HTMLResponse:
         )
         status = "paused" if paused else "running"
         rows.append(
-            f"<tr><td>{name}</td><td>{stage or ''}</td><td>{ts or ''}</td><td>{status}</td><td>{button}</td></tr>"
+            "<tr>"
+            f"<td>{name}</td>"
+            f"<td>{stage or ''}</td>"
+            f"<td>{ts or ''}</td>"
+            f"<td>{status}</td>"
+            f"<td>{pointer_count or ''}</td>"
+            f"<td>{button}</td>"
+            "</tr>"
         )
     body = """
     <html><body>
     <h1>Cascadence Dashboard</h1>
     <table>
-    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Control</th></tr>
+    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Pointers</th><th>Control</th></tr>
     {rows}
     </table>
     </body></html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from task_cascadence.dashboard import app, StageStore
 from task_cascadence.scheduler import BaseScheduler
-from task_cascadence.plugins import ExampleTask
+from task_cascadence.plugins import ExampleTask, PointerTask
 
 
 def setup(monkeypatch, tmp_path):
@@ -38,3 +38,30 @@ def test_pause_resume(monkeypatch, tmp_path):
     resp = client.post("/resume/example", follow_redirects=False)
     assert resp.status_code == 303
     assert sched._tasks["example"]["paused"] is False
+
+
+def test_dashboard_pointer_counts(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(tmp_path / "pointers.yml"))
+
+    class DemoPointer(PointerTask):
+        name = "demo_pointer"
+
+    sched = BaseScheduler()
+    task = DemoPointer()
+    task.add_pointer("alice", "run1")
+    task.add_pointer("bob", "run2")
+    sched.register_task("demo_pointer", task)
+    monkeypatch.setattr(
+        "task_cascadence.dashboard.get_default_scheduler",
+        lambda: sched,
+    )
+    store = StageStore(path=tmp_path / "stages.yml")
+    monkeypatch.setattr("task_cascadence.dashboard.StageStore", lambda: store)
+
+    client = TestClient(app)
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    assert "<th>Pointers</th>" in resp.text
+    assert "<td>2</td>" in resp.text


### PR DESCRIPTION
## Summary
- show pointer counts per task on the FastAPI dashboard
- verify dashboard pointer counts with new test
- clean up unused imports in API module

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68829ad82ef88326a9cddddfb1ffac72