### PR TITLE
Add optional ai_plan planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ pipeline.run(user_id="alice")
 
 The optional ``research`` step relies on the ``tino_storm`` package which may
 be installed separately. The provided ``user_id`` is hashed before transport.
+If the optional ``ai_plan`` package is present, tasks without a ``plan`` method
+fall back to ``ai_plan.plan`` during the planning stage.
 
 ## Command Line Usage
 
@@ -339,6 +341,8 @@ pointers_path: /tmp/pointers.yml
 
 Install ``tino_storm`` to allow tasks to perform research queries during the
 ``research`` pipeline stage.
+Install ``ai_plan`` if you want automatic planning for tasks missing a ``plan``
+method.
 
 ## Hashing User IDs
 

--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -28,7 +28,6 @@ def dashboard(request: Request) -> HTMLResponse:
         ts = event.get("time") if event else None
         pointer_count = len(pointers.get_pointers(name))
         paused = info.get("paused", False)
-        ptrs = len(p_store.get_pointers(name))
         button = (
             f"<form method='post' action='/resume/{name}'>"
             "<button type='submit'>Resume</button></form>"

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -8,6 +8,11 @@ from typing import Any
 from uuid import uuid4
 import asyncio
 
+try:
+    import ai_plan  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may be missing
+    ai_plan = None  # type: ignore
+
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from .ume import emit_task_spec, emit_task_run, emit_stage_update
@@ -67,6 +72,8 @@ class TaskPipeline:
         plan_result = None
         if hasattr(self.task, "plan"):
             plan_result = self.task.plan()
+        elif ai_plan is not None and hasattr(ai_plan, "plan"):
+            plan_result = ai_plan.plan(self.task)
         self._emit_stage("planning", user_id)
         return plan_result
 


### PR DESCRIPTION
## Summary
- integrate ai_plan if installed for planning
- fix undefined variable in dashboard
- document ai_plan usage

## Testing
- `ruff check .`
- `mypy task_cascadence`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a4825edc8326bdddb3bc99962be1