### PR TITLE
Expand orchestrated mod example

### DIFF
--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -28,7 +28,6 @@ def dashboard(request: Request) -> HTMLResponse:
         ts = event.get("time") if event else None
         pointer_count = len(pointers.get_pointers(name))
         paused = info.get("paused", False)
-        ptrs = len(p_store.get_pointers(name))
         button = (
             f"<form method='post' action='/resume/{name}'>"
             "<button type='submit'>Resume</button></form>"


### PR DESCRIPTION
## Summary
- implement multi-stage `ModSetup` task with planner stage
- update dashboard to remove stray variable

## Testing
- `ruff check examples/orchestrated_mod_setup.py task_cascadence/dashboard/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882a483737483269eef5f7ebb5b4b5d