### PR TITLE
Add runtime pipeline pause/resume

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -17,6 +17,7 @@ from ..scheduler import (
     CronScheduler,
     BaseScheduler,
 )
+from ..pipeline_registry import get_pipeline
 from .. import plugins  # noqa: F401
 from ..metrics import start_metrics_server  # noqa: F401
 from ..pointer_store import PointerStore
@@ -152,7 +153,11 @@ def pause_task(name: str) -> None:
     """Pause ``NAME`` so it temporarily stops running."""
 
     try:
-        get_default_scheduler().pause_task(name)
+        pipeline = get_pipeline(name)
+        if pipeline:
+            pipeline.pause()
+        else:
+            get_default_scheduler().pause_task(name)
         typer.echo(f"{name} paused")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)
@@ -164,7 +169,11 @@ def resume_task(name: str) -> None:
     """Resume a paused task called ``NAME``."""
 
     try:
-        get_default_scheduler().resume_task(name)
+        pipeline = get_pipeline(name)
+        if pipeline:
+            pipeline.resume()
+        else:
+            get_default_scheduler().resume_task(name)
         typer.echo(f"{name} resumed")
     except Exception as exc:  # pragma: no cover - simple error propagation
         typer.echo(f"error: {exc}", err=True)

--- a/task_cascadence/pipeline_registry.py
+++ b/task_cascadence/pipeline_registry.py
@@ -1,0 +1,30 @@
+"""Registry of running :class:`~task_cascadence.orchestrator.TaskPipeline` instances."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .orchestrator import TaskPipeline
+
+# Running pipelines keyed by task name
+_running_pipelines: Dict[str, TaskPipeline] = {}
+
+
+def add_pipeline(name: str, pipeline: TaskPipeline) -> None:
+    """Register *pipeline* under *name*."""
+    _running_pipelines[name] = pipeline
+
+
+def remove_pipeline(name: str) -> None:
+    """Remove the pipeline registered as *name* if present."""
+    _running_pipelines.pop(name, None)
+
+
+def get_pipeline(name: str) -> Optional[TaskPipeline]:
+    """Return the pipeline registered as *name* if running."""
+    return _running_pipelines.get(name)
+
+
+def list_pipelines() -> Dict[str, TaskPipeline]:
+    """Return a copy of the currently registered pipelines."""
+    return dict(_running_pipelines)

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -85,6 +85,7 @@ class BaseScheduler:
             from ..ume import emit_task_run
             from ..ume.models import TaskRun, TaskSpec
             from ..orchestrator import TaskPipeline
+            from ..pipeline_registry import add_pipeline, remove_pipeline
 
             spec = TaskSpec(id=task.__class__.__name__, name=task.__class__.__name__)
 
@@ -100,7 +101,11 @@ class BaseScheduler:
                         for attr in ("intake", "research", "plan", "verify")
                     ):
                         pipeline = TaskPipeline(task)
-                        result = pipeline.run(user_id=user_id)
+                        add_pipeline(name, pipeline)
+                        try:
+                            result = pipeline.run(user_id=user_id)
+                        finally:
+                            remove_pipeline(name)
                     else:
                         result = task.run()
                 except Exception:

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -4,6 +4,9 @@ from task_cascadence.api import app
 from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.stage_store import StageStore
+from task_cascadence.pipeline_registry import get_pipeline
+import threading
+import time
 
 
 def setup_scheduler(monkeypatch, tmp_path):
@@ -35,6 +38,45 @@ def test_api_pause_resume(monkeypatch, tmp_path):
     events = StageStore(path=tmp_path / "stages.yml").get_events("example")
     assert events[-1]["stage"] == "resumed"
     assert "time" in events[-1]
+
+
+class SlowTask(ExampleTask):
+    name = "slow"
+
+    def intake(self):
+        time.sleep(0.05)
+
+    def run(self):
+        time.sleep(0.2)
+        return "ok"
+
+
+def test_api_pause_running_pipeline(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "s2.yml"))
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    sched = CronScheduler(storage_path=tmp_path / "sched2.yml")
+    task = SlowTask()
+    sched.register_task("slow", task)
+    monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+
+    client = TestClient(app)
+    thread = threading.Thread(target=lambda: sched.run_task("slow"))
+    thread.start()
+    time.sleep(0.05)
+    resp = client.post("/tasks/slow/pause")
+    assert resp.status_code == 200
+    pipeline = get_pipeline("slow")
+    assert pipeline is not None and pipeline._paused is True
+    assert thread.is_alive()
+    resp = client.post("/tasks/slow/resume")
+    assert resp.status_code == 200
+    thread.join()
+    assert pipeline._paused is False
 
 
 def test_api_pipeline_status(monkeypatch, tmp_path):

--- a/tests/test_cli_pause.py
+++ b/tests/test_cli_pause.py
@@ -4,6 +4,9 @@ from task_cascadence.cli import app
 from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask, CronTask
 from task_cascadence.stage_store import StageStore
+from task_cascadence.pipeline_registry import get_pipeline
+import threading
+import time
 
 
 
@@ -29,6 +32,45 @@ def test_cli_pause_resume(monkeypatch, tmp_path):
     assert sched._tasks["example"]["paused"] is False
     events = StageStore(path=tmp_path / "stages.yml").get_events("example")
     assert events[-1]["stage"] == "resumed"
+
+
+class SlowTask(CronTask):
+    name = "slow"
+
+    def intake(self):
+        time.sleep(0.05)
+
+    def run(self):
+        time.sleep(0.2)
+        return "ok"
+
+
+def test_pause_running_pipeline(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    sched = CronScheduler(storage_path=tmp_path / "sched2.yml")
+    task = SlowTask()
+    sched.register_task("slow", task)
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+
+    runner = CliRunner()
+    thread = threading.Thread(target=lambda: sched.run_task("slow"))
+    thread.start()
+    time.sleep(0.05)
+    result = runner.invoke(app, ["pause", "slow"])
+    assert result.exit_code == 0
+    pipeline = get_pipeline("slow")
+    assert pipeline is not None and pipeline._paused is True
+    assert thread.is_alive()
+    result = runner.invoke(app, ["resume", "slow"])
+    assert result.exit_code == 0
+    thread.join()
+    assert pipeline._paused is False
 
 
 class DummyTask(CronTask):


### PR DESCRIPTION
## Summary
- add `pipeline_registry` to track running pipelines
- extend `TaskPipeline` with pause/resume handling
- check paused state during execution
- update CLI and API pause/resume commands to affect running pipelines
- store active pipelines in scheduler
- test pausing active pipelines via CLI and API

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d3c4e9e4832682e04cd84f165efe