### PR TITLE
Add d0tTino CronTask plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,19 @@ $ task list
 
 ``DemoTask`` from the plugin will appear alongside the built-in example task.
 
+The package also ships with ``D0tTinoTask`` which talks to the
+`d0tTino` helpers.  It invokes ``d0tTino ai-plan`` during the planning stage
+and ``d0tTino ai`` when running.  Instantiate it with a prompt and optionally
+``use_api=True`` to call a running API server:
+
+```python
+from task_cascadence.plugins import D0tTinoTask
+
+task = D0tTinoTask("Hello world")
+task.plan()
+task.run()
+```
+
 ## Environment Variables
 
 ``load_config`` merges values from a YAML file specified by ``CASCADENCE_CONFIG``

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -128,6 +128,12 @@ registered_tasks: Dict[str, BaseTask] = {
     ExampleTask.name: ExampleTask(),
 }
 
+try:
+    _tino_cls = importlib.import_module("task_cascadence.plugins.d0tTino").D0tTinoTask
+    registered_tasks[_tino_cls.name] = _tino_cls()
+except Exception:  # pragma: no cover - optional plugin may fail to import
+    pass
+
 def load_plugin(path: str) -> BaseTask:
     """Load ``path`` of the form ``module:Class`` and return an instance."""
 

--- a/task_cascadence/plugins/d0tTino.py
+++ b/task_cascadence/plugins/d0tTino.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+
+import requests
+
+from . import CronTask
+
+
+class D0tTinoTask(CronTask):
+    """Cron task calling out to d0tTino's AI helpers."""
+
+    name = "d0tTino"
+
+    def __init__(self, prompt: str = "ping", *, use_api: bool = False, base_url: str = "http://localhost:8080") -> None:
+        self.prompt = prompt
+        self.use_api = use_api
+        self.base_url = base_url.rstrip("/")
+
+    def _call(self, command: str) -> str:
+        if self.use_api:
+            url = f"{self.base_url}/{command}"
+            response = requests.post(url, json={"prompt": self.prompt}, timeout=30)
+            response.raise_for_status()
+            return response.text.strip()
+        result = subprocess.run(
+            ["d0tTino", command, self.prompt],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def plan(self) -> str:
+        """Invoke the ``ai-plan`` helper."""
+        return self._call("ai-plan")
+
+    def run(self) -> str:
+        """Invoke the ``ai`` helper."""
+        return self._call("ai")

--- a/tests/test_d0ttino_plugin.py
+++ b/tests/test_d0ttino_plugin.py
@@ -1,0 +1,51 @@
+import subprocess
+
+import requests
+
+from task_cascadence.plugins.d0tTino import D0tTinoTask
+
+
+class DummyCompleted:
+    def __init__(self, out: str) -> None:
+        self.stdout = out
+
+
+def test_cli_invocation(monkeypatch):
+    captured = {}
+
+    def fake_run(args, capture_output=False, text=False, check=False):
+        captured["args"] = args
+        return DummyCompleted("ok")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    task = D0tTinoTask("ping")
+    result = task.run()
+
+    assert result == "ok"
+    assert captured["args"] == ["d0tTino", "ai", "ping"]
+
+
+def test_api_invocation(monkeypatch):
+    class Resp:
+        def __init__(self, txt: str) -> None:
+            self.text = txt
+
+        def raise_for_status(self) -> None:
+            pass
+
+    captured = {}
+
+    def fake_post(url, json=None, timeout=0):
+        captured["url"] = url
+        captured["json"] = json
+        return Resp("plan")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    task = D0tTinoTask("data", use_api=True, base_url="http://api")
+    result = task.plan()
+
+    assert result == "plan"
+    assert captured["url"] == "http://api/ai-plan"
+    assert captured["json"] == {"prompt": "data"}


### PR DESCRIPTION
## Summary
- add a CronTask plugin that integrates with d0tTino helpers
- register the plugin dynamically
- document `D0tTinoTask` in the README
- test the new plugin via mocked subprocess and HTTP calls

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e1b29b7883268b95fbc05c85b29b