### PR TITLE
Enhance dashboard with queue and status info

### DIFF
--- a/task_cascadence/dashboard/__init__.py
+++ b/task_cascadence/dashboard/__init__.py
@@ -15,18 +15,30 @@ def _get_event(store: StageStore, task_name: str) -> dict | None:
     return events[-1] if events else None
 
 
+def _get_last_status(store: StageStore, task_name: str) -> str | None:
+    events = store.get_events(task_name)
+    for event in reversed(events):
+        stage = event.get("stage")
+        if stage in ("finish", "error"):
+            return stage
+    return None
+
+
 @app.get("/", response_class=HTMLResponse)
 def dashboard(request: Request) -> HTMLResponse:
     store = StageStore()
     pointers = PointerStore()
 
     sched = get_default_scheduler()
-    rows = []
+    rows: list[str] = []
+    queued: list[str] = []
     for name, info in sched._tasks.items():
         event = _get_event(store, name)
         stage = event["stage"] if event else None
         ts = event.get("time") if event else None
         pointer_count = len(pointers.get_pointers(name))
+        if pointer_count:
+            queued.append(name)
         paused = info.get("paused", False)
         button = (
             f"<form method='post' action='/resume/{name}'>"
@@ -38,6 +50,7 @@ def dashboard(request: Request) -> HTMLResponse:
             )
         )
         status = "paused" if paused else "running"
+        last_status = _get_last_status(store, name) or ""
         rows.append(
             "<tr>"
             f"<td>{name}</td>"
@@ -45,19 +58,24 @@ def dashboard(request: Request) -> HTMLResponse:
             f"<td>{ts or ''}</td>"
             f"<td>{status}</td>"
             f"<td>{pointer_count or ''}</td>"
+            f"<td>{last_status}</td>"
             f"<td>{button}</td>"
             "</tr>"
-
+            ""
         )
+
+    queued_items = "\n".join(f"<li>{q}</li>" for q in queued) or "<li>None</li>"
     body = """
     <html><body>
     <h1>Cascadence Dashboard</h1>
+    <h2>Queued Tasks</h2>
+    <ul>{queued}</ul>
     <table>
-    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Pointers</th><th>Control</th></tr>
+    <tr><th>Task</th><th>Stage</th><th>Time</th><th>Status</th><th>Pointers</th><th>Last Run</th><th>Control</th></tr>
     {rows}
     </table>
     </body></html>
-    """.format(rows="\n".join(rows))
+    """.format(rows="\n".join(rows), queued=queued_items)
     return HTMLResponse(body)
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -22,8 +22,9 @@ def setup(monkeypatch, tmp_path):
 def test_dashboard_index(monkeypatch, tmp_path):
     sched, s_store, p_store = setup(monkeypatch, tmp_path)
     s_store.add_event("example", "run", None)
+    s_store.add_event("example", "finish", None)
     p_store.add_pointer("example", "alice", "r1")
-    ts = s_store.get_events("example")[0]["time"]
+    ts = s_store.get_events("example")[-1]["time"]
     client = TestClient(app)
     resp = client.get("/")
     assert resp.status_code == 200
@@ -31,6 +32,10 @@ def test_dashboard_index(monkeypatch, tmp_path):
     assert "run" in resp.text
     assert ts in resp.text
     assert "<td>1</td>" in resp.text
+    assert "Queued Tasks" in resp.text
+    assert "<li>example</li>" in resp.text
+    assert "<th>Last Run</th>" in resp.text
+    assert "finish" in resp.text
 
 
 def test_pause_resume(monkeypatch, tmp_path):
@@ -68,4 +73,6 @@ def test_dashboard_pointer_counts(monkeypatch, tmp_path):
 
     assert resp.status_code == 200
     assert "<th>Pointers</th>" in resp.text
+    assert "<th>Last Run</th>" in resp.text
     assert "<td>2</td>" in resp.text
+


### PR DESCRIPTION
## Summary
- display queued tasks using PointerStore
- show last run status via StageStore
- expand dashboard tests

## Testing
- `ruff check task_cascadence/dashboard/__init__.py tests/test_dashboard.py`
- `mypy`
- `pytest tests/test_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ea474ec48326ae8355021273c570