### PR TITLE
Add dynamic task API and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ import httpx
 
 tasks = httpx.get("http://localhost:8000/tasks").json()
 httpx.post("http://localhost:8000/tasks/example/run", headers={"X-User-ID": "bob"})
+
+# capture a task definition from another machine
+httpx.post(
+    "http://localhost:8000/tasks",
+    params={"path": "myproject.tasks:Demo", "schedule": "0 * * * *"},
+)
 ```
+
+This allows capturing a task definition on one device and registering it on another.
 
 Including the ``X-User-ID`` header attaches a hashed identifier to emitted
 events, aligning with the project's privacy goals.
@@ -336,9 +344,10 @@ with the variables below. When set, they override values from the YAML file:
     Location of the ``stages.yml`` file used by :class:`StageStore`.
 ``CASCADENCE_POINTERS_PATH``
     Location of the ``pointers.yml`` file used by :class:`PointerStore`.
+``CASCADENCE_TASKS_PATH``
+    Location of the ``tasks.yml`` file used by :class:`TaskStore`.
 
-The YAML configuration may also define ``stages_path`` and ``pointers_path``
-to override these defaults.
+The YAML configuration may also define ``stages_path``, ``pointers_path`` and ``tasks_path`` to override these defaults.
 
 Example ``cascadence.yml`` enabling gRPC transport and research support:
 
@@ -350,6 +359,7 @@ ume_grpc_method: Send
 hash_secret: supersecret
 stages_path: /tmp/stages.yml
 pointers_path: /tmp/pointers.yml
+tasks_path: /tmp/tasks.yml
 ```
 
 Install ``tino_storm`` to allow tasks to perform research queries during the

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -386,11 +386,12 @@ def get_default_scheduler() -> BaseScheduler:
 default_scheduler = get_default_scheduler
 
 
-def create_scheduler(backend: str) -> BaseScheduler:
+def create_scheduler(backend: str, tasks: dict[str, Any] | None = None) -> BaseScheduler:
     """Factory returning a scheduler for ``backend``."""
 
+    tasks = tasks or {}
     if backend == "cron":
-        return CronScheduler()
+        return CronScheduler(tasks=tasks)
     if backend == "base":
         return BaseScheduler()
     if backend == "temporal":
@@ -400,7 +401,7 @@ def create_scheduler(backend: str) -> BaseScheduler:
         return CronyxScheduler()
     if backend == "dag":
         from .dag import DagCronScheduler
-        return DagCronScheduler()
+        return DagCronScheduler(tasks=tasks)
     raise ValueError(f"Unknown scheduler backend: {backend}")
 
 

--- a/task_cascadence/task_store.py
+++ b/task_cascadence/task_store.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Dict, List
+
+import yaml
+
+from .config import load_config
+from . import plugins
+
+
+class TaskStore:
+    """Persistent store for dynamically registered tasks."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_TASKS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("tasks_path")
+        if path is None:
+            path = Path.home() / ".cascadence" / "tasks.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: List[str] = self._load()
+
+    def _load(self) -> List[str]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or []
+                if isinstance(data, list):
+                    return data
+        return []
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_path(self, module_path: str) -> None:
+        if module_path not in self._data:
+            self._data.append(module_path)
+            self._save()
+
+    def get_paths(self) -> List[str]:
+        return list(self._data)
+
+    def load_tasks(self) -> Dict[str, plugins.BaseTask]:
+        tasks: Dict[str, plugins.BaseTask] = {}
+        for path in self._data:
+            try:
+                task = plugins.load_plugin(path)
+            except Exception:
+                continue
+            tasks[task.__class__.__name__] = task
+        return tasks

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ import tempfile
 from task_cascadence.api import app
 from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import CronTask
+import yaml
 
 
 class DummyTask(CronTask):
@@ -18,27 +19,35 @@ class DummyTask(CronTask):
         return "ok"
 
 
-def setup_scheduler(monkeypatch):
-    sched = CronScheduler(storage_path="/tmp/sched.yml")
+class DynamicTask(CronTask):
+    name = "dynamic"
+
+    def run(self):
+        return "dyn"
+
+
+def setup_scheduler(monkeypatch, tmp_path):
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
     task = DummyTask()
     sched.register_task(name_or_task="dummy", task_or_expr=task)
     monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
     monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda run, user_id=None: None)
     tmp = tempfile.NamedTemporaryFile(delete=False)
     monkeypatch.setenv("CASCADENCE_POINTERS_PATH", tmp.name)
+    monkeypatch.setenv("CASCADENCE_TASKS_PATH", str(tmp_path / "tasks.yml"))
     return sched, task
 
 
-def test_list_tasks(monkeypatch):
-    sched, _task = setup_scheduler(monkeypatch)
+def test_list_tasks(monkeypatch, tmp_path):
+    sched, _task = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.get("/tasks")
     assert resp.status_code == 200
     assert resp.json() == [{"name": "dummy", "disabled": False}]
 
 
-def test_run_task(monkeypatch):
-    sched, task = setup_scheduler(monkeypatch)
+def test_run_task(monkeypatch, tmp_path):
+    sched, task = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.post("/tasks/dummy/run")
     assert resp.status_code == 200
@@ -46,22 +55,22 @@ def test_run_task(monkeypatch):
     assert task.ran == 1
 
 
-def test_run_task_user_header(monkeypatch):
+def test_run_task_user_header(monkeypatch, tmp_path):
     called = {}
 
     def fake_run(name, use_temporal=False, user_id=None):
         called["uid"] = user_id
         return "r"
 
-    sched, _ = setup_scheduler(monkeypatch)
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
     monkeypatch.setattr(sched, "run_task", fake_run)
     client = TestClient(app)
     client.post("/tasks/dummy/run", headers={"X-User-ID": "alice"})
     assert called["uid"] == "alice"
 
 
-def test_schedule_task(monkeypatch):
-    sched, _ = setup_scheduler(monkeypatch)
+def test_schedule_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.post("/tasks/dummy/schedule", params={"expression": "*/5 * * * *"})
     assert resp.status_code == 200
@@ -69,9 +78,35 @@ def test_schedule_task(monkeypatch):
     assert job is not None
 
 
-def test_disable_task(monkeypatch):
-    sched, _ = setup_scheduler(monkeypatch)
+def test_disable_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.post("/tasks/dummy/disable")
     assert resp.status_code == 200
     assert sched._tasks["dummy"]["disabled"] is True
+
+
+def test_register_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post("/tasks", params={"path": "tests.test_api:DynamicTask"})
+    assert resp.status_code == 200
+    assert "dynamic" in [name for name, _ in sched.list_tasks()]
+    data = yaml.safe_load(open(tmp_path / "tasks.yml").read())
+    assert "tests.test_api:DynamicTask" in data
+    run = client.post("/tasks/dynamic/run")
+    assert run.status_code == 200
+    assert run.json()["result"] == "dyn"
+
+
+def test_register_task_with_schedule(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post(
+        "/tasks",
+        params={"path": "tests.test_api:DynamicTask", "schedule": "*/5 * * * *"},
+    )
+    assert resp.status_code == 200
+    job = sched.scheduler.get_job("DynamicTask")
+    assert job is not None
+


### PR DESCRIPTION
## Summary
- allow POST /tasks to dynamically load and schedule tasks
- persist dynamically added tasks with `TaskStore`
- load persisted tasks during initialization and plugin reloads
- document task capture from other devices and `CASCADENCE_TASKS_PATH`
- test task registration API

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ea46b7188326b4d3d8073f28ed3e