### PR TITLE
Enable async run in scheduler

### DIFF
--- a/tests/test_async_run.py
+++ b/tests/test_async_run.py
@@ -1,0 +1,18 @@
+import asyncio
+from task_cascadence.scheduler import BaseScheduler
+
+
+class AsyncTask:
+    async def run(self):
+        await asyncio.sleep(0)
+        return "async"
+
+def test_async_run(monkeypatch):
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+
+    sched = BaseScheduler()
+    sched.register_task("async", AsyncTask())
+    result = sched.run_task("async")
+    assert result == "async"


### PR DESCRIPTION
## Summary
- detect coroutine run methods in `TaskPipeline._call_run`
- execute async runs with `asyncio.run` when needed
- await run results in `BaseScheduler.run_task`
- add a test for async `run` support

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d1f5547c8326894ae8aa3853d599