### PR TITLE
Add thread helpers and locking tests

### DIFF
--- a/tests/test_store_locking.py
+++ b/tests/test_store_locking.py
@@ -1,0 +1,32 @@
+import yaml
+from task_cascadence.pointer_store import PointerStore
+from task_cascadence.stage_store import StageStore
+from task_cascadence.ume import _hash_user_id
+from tests.utils.threads import run_workers
+
+
+def test_pointer_store_parallel_writes(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    path = tmp_path / "pointers.yml"
+    store = PointerStore(path=path)
+
+    def worker(_):
+        store.add_pointer("demo", "alice", "r1")
+
+    run_workers(worker, workers=5, iterations=10)
+
+    data = yaml.safe_load(path.read_text())
+    assert data == {"demo": [{"run_id": "r1", "user_hash": _hash_user_id("alice")}]}
+
+
+def test_stage_store_parallel_writes(tmp_path):
+    path = tmp_path / "stages.yml"
+    store = StageStore(path=path)
+
+    def worker(i):
+        store.add_event("demo", f"stage-{i}", None)
+
+    run_workers(worker, workers=5, iterations=20)
+
+    data = yaml.safe_load(path.read_text())
+    assert len(data["demo"]) == 100

--- a/tests/utils/threads.py
+++ b/tests/utils/threads.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from threading import Thread
+from typing import Callable
+
+
+def run_workers(func: Callable[[int], None], workers: int = 2, iterations: int = 1) -> None:
+    """Run *func* concurrently across multiple worker threads."""
+
+    def _run(worker_id: int) -> None:
+        for _ in range(iterations):
+            func(worker_id)
+
+    threads = [Thread(target=_run, args=(i,)) for i in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()


### PR DESCRIPTION
## Summary
- add `tests/utils` package with worker thread helper
- create locking tests for pointer and stage stores using the helper

## Testing
- `ruff check tests/utils/threads.py tests/test_store_locking.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e43fd06083268df84c5dae8c7ad6