### PR TITLE
Implement file locking for StageStore

### DIFF
--- a/tests/test_stage_store.py
+++ b/tests/test_stage_store.py
@@ -1,0 +1,29 @@
+import threading
+import yaml
+from task_cascadence.stage_store import StageStore
+
+
+def test_concurrent_writes(tmp_path):
+    path = tmp_path / "stages.yml"
+    barrier = threading.Barrier(5)
+    errors = []
+
+    store = StageStore(path=path)
+
+    def worker(i: int) -> None:
+        try:
+            barrier.wait()
+            store.add_event("t", f"s{i}", None)
+        except Exception as e:  # pragma: no cover - failure info
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    data = yaml.safe_load(path.read_text())
+    stages = sorted(e["stage"] for e in data["t"])
+    assert stages == [f"s{i}" for i in range(5)]


### PR DESCRIPTION
## Summary
- ensure StageStore writes use an exclusive OS file lock
- release the lock after saving
- add a regression test for concurrent StageStore writes

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e43e9fc88326b907b8c1779e4449