### PR TITLE
Add plugin watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ task schedule NAME CRON  # register a cron schedule
 $ task schedules       # list configured schedules
 $ task export-n8n FILE # dump tasks as n8n workflow
 $ task webhook [--host HOST] [--port PORT]  # start webhook server
+$ task watch-plugins DIR # reload plugins on changes in DIR
 ```
 
 Global options allow metrics and UME transport configuration:

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -350,6 +350,25 @@ def pointer_sync_cmd() -> None:
     pointer_sync.run()
 
 
+@app.command("watch-plugins")
+def watch_plugins(directory: str = typer.Argument(".")) -> None:
+    """Reload plugins when files in ``DIRECTORY`` change."""
+
+    from ..plugins.watcher import PluginWatcher
+    import time
+
+    watcher = PluginWatcher(directory)
+    watcher.start()
+    typer.echo(f"watching {directory}... press Ctrl+C to stop")
+    try:
+        while True:  # pragma: no cover - loop interrupted by KeyboardInterrupt
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        pass
+    finally:
+        watcher.stop()
+
+
 
 def main(args: list[str] | None = None) -> None:
     """CLI entry point used by ``console_scripts`` or directly.
@@ -378,5 +397,6 @@ __all__ = [
     "pointer_send",
     "pointer_receive",
     "pointer_sync_cmd",
+    "watch_plugins",
 ]
 

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -24,7 +24,7 @@ class _ReloadHandler(FileSystemEventHandler):
         if now - self._start < 0.5:
             return
         path, last = self._last
-        if event.src_path == path and now - last < 1:
+        if event.src_path == path and now - last < 1.5:
             return
 
         self._last = (event.src_path, now)

--- a/tests/test_watch_plugins_cli.py
+++ b/tests/test_watch_plugins_cli.py
@@ -1,0 +1,33 @@
+import time
+from typer.testing import CliRunner
+
+from task_cascadence.cli import app
+
+
+def test_cli_watch_plugins(monkeypatch, tmp_path):
+    events = []
+
+    class DummyWatcher:
+        def __init__(self, path):
+            events.append(("init", path))
+
+        def start(self):
+            events.append("start")
+
+        def stop(self):
+            events.append("stop")
+
+    monkeypatch.setattr(
+        "task_cascadence.plugins.watcher.PluginWatcher", DummyWatcher
+    )
+
+    def raise_interrupt(_):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(time, "sleep", raise_interrupt)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["watch-plugins", str(tmp_path)])
+    assert result.exit_code == 0
+    assert events == [("init", str(tmp_path)), "start", "stop"]
+


### PR DESCRIPTION
## Summary
- add a `watch-plugins` command to the CLI
- update plugin watcher debounce logic
- document plugin watching
- test the new command

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f14f17c88326b7248187d92ab709