### PR TITLE
Add watch-plugins command and tests

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -23,6 +23,7 @@ from ..metrics import start_metrics_server  # noqa: F401
 from ..pointer_store import PointerStore
 import task_cascadence as tc
 from ..n8n import export_workflow
+import time
 
 from typing import Callable, Union
 
@@ -268,6 +269,23 @@ def reload_plugins_cmd() -> None:
     typer.echo("plugins reloaded")
 
 
+@app.command("watch-plugins")
+def watch_plugins(path: str) -> None:
+    """Watch ``PATH`` for plugin changes."""
+
+    from ..plugins.watcher import PluginWatcher
+
+    watcher = PluginWatcher(path)
+    watcher.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        pass
+    finally:
+        watcher.stop()
+
+
 def _pointer_add(name: str, user_id: str, run_id: str) -> None:
     sched = get_default_scheduler()
     task_info = dict(sched._tasks).get(name)
@@ -373,6 +391,7 @@ __all__ = [
     "webhook",
     "start_metrics_server",
     "reload_plugins_cmd",
+    "watch_plugins",
     "pointer_add",
     "pointer_list",
     "pointer_send",

--- a/task_cascadence/plugins/watcher.py
+++ b/task_cascadence/plugins/watcher.py
@@ -24,7 +24,7 @@ class _ReloadHandler(FileSystemEventHandler):
         if now - self._start < 0.5:
             return
         path, last = self._last
-        if event.src_path == path and now - last < 1:
+        if event.src_path == path and now - last < 2:
             return
 
         self._last = (event.src_path, now)


### PR DESCRIPTION
## Summary
- add `watch-plugins` command to CLI
- debounce plugin reloads for 2s
- test that `task watch-plugins` starts and stops the plugin watcher

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f14fc7208326a50284366327a95e