### PR TITLE
Add async step to mod setup example

### DIFF
--- a/examples/orchestrated_mod_setup.py
+++ b/examples/orchestrated_mod_setup.py
@@ -1,5 +1,7 @@
 """Example demonstrating staged mod installation with pause/resume."""
 
+import asyncio
+
 from task_cascadence.scheduler.dag import DagCronScheduler
 from task_cascadence.plugins import CronTask
 from task_cascadence.ume import emit_stage_update
@@ -25,10 +27,11 @@ class ModSetup(CronTask):
         self._plan = plan_mod_setup()
         return self._plan
 
-    def run(self) -> None:
+    async def run(self) -> None:
         for step in self._plan:
             if step == "download":
                 print("Downloading mod archive")
+                await asyncio.sleep(0.1)
             elif step == "install":
                 print("Installing mod")
             elif step == "enable":


### PR DESCRIPTION
## Summary
- import asyncio and add an async run stage
- simulate async download delay with asyncio.sleep

## Testing
- `ruff check examples/orchestrated_mod_setup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886855426348326817085f957db1b6c