### PR TITLE
Implement idea submission API

### DIFF
--- a/task_cascadence/idea_store.py
+++ b/task_cascadence/idea_store.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import uuid
+from typing import Dict
+
+import yaml
+
+from .config import load_config
+
+
+class IdeaStore:
+    """Persistent store for submitted ideas."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_IDEAS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("ideas_path")
+        if path is None:
+            path = Path.home() / ".cascadence" / "ideas.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: Dict[str, str] = self._load()
+
+    def _load(self) -> Dict[str, str]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or {}
+                if isinstance(data, dict):
+                    return {str(k): str(v) for k, v in data.items()}
+        return {}
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_idea(self, idea: str) -> str:
+        idea_id = uuid.uuid4().hex
+        self._data[idea_id] = idea
+        self._save()
+        return idea_id
+
+    def get_idea(self, idea_id: str) -> str | None:
+        return self._data.get(idea_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,3 +127,25 @@ def test_register_task_with_schedule(monkeypatch, tmp_path):
     job = sched.scheduler.get_job("DynamicTask")
     assert job is not None
 
+
+def test_idea_submit_and_get(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_IDEAS_PATH", str(tmp_path / "ideas.yml"))
+    client = TestClient(app)
+
+    resp = client.post("/ideas", json={"idea": "hello"})
+    assert resp.status_code == 200
+    idea_id = resp.json()["id"]
+    assert isinstance(idea_id, str)
+
+    resp = client.get(f"/ideas/{idea_id}")
+    assert resp.status_code == 200
+    assert resp.json() == {"id": idea_id, "idea": "hello"}
+
+
+def test_idea_validation(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_IDEAS_PATH", str(tmp_path / "ideas.yml"))
+    client = TestClient(app)
+
+    resp = client.post("/ideas", json={"idea": " "})
+    assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- add `IdeaStore` for persisting submitted ideas
- expose `/ideas` POST route to store ideas
- expose `/ideas/{id}` GET route
- test idea submission and retrieval

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e8e22a1883268f0015f268e055f3