### PR TITLE
Add missing tino_storm runtime error test

### DIFF
--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from task_cascadence.orchestrator import TaskPipeline
 
@@ -109,3 +110,13 @@ def test_async_research_method(monkeypatch):
     assert result == "info2"
     assert steps == ["research:bar"]
     assert emitted == ["research"]
+
+
+def test_gather_missing_tino_storm(monkeypatch):
+    """``gather`` raises ``RuntimeError`` when ``tino_storm`` is missing."""
+    import task_cascadence.research as research
+
+    monkeypatch.setattr(research, "tino_storm", None)
+
+    with pytest.raises(RuntimeError):
+        research.gather("query")


### PR DESCRIPTION
## Summary
- add `pytest` import for research tests
- test that `gather()` raises when `tino_storm` is missing

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688790b0f48883269579261a12e55c62