### PR TITLE
Add StageStore thread-safety test

### DIFF
--- a/tests/test_stage_store.py
+++ b/tests/test_stage_store.py
@@ -27,3 +27,18 @@ def test_concurrent_writes(tmp_path):
     data = yaml.safe_load(path.read_text())
     stages = sorted(e["stage"] for e in data["t"])
     assert stages == [f"s{i}" for i in range(5)]
+
+
+def test_add_event_threads(tmp_path):
+    path = tmp_path / "stages.yml"
+    store = StageStore(path=path)
+
+    def worker(_: int) -> None:
+        store.add_event("t", "s", None)
+
+    from tests.utils.threads import run_workers
+
+    run_workers(worker, workers=2, iterations=3)
+
+    data = yaml.safe_load(path.read_text())
+    assert len(data["t"]) == 6


### PR DESCRIPTION
## Summary
- extend test_stage_store with a new concurrency test
- use the run_workers helper to run StageStore.add_event from two threads

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688790b101e08326a140c1e778911b91