### PR TITLE
Add TaskStore unit test

### DIFF
--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -1,0 +1,30 @@
+import sys
+from task_cascadence.task_store import TaskStore
+from task_cascadence import plugins
+
+
+def test_add_path_deduplicates_and_loads(tmp_path, monkeypatch):
+    tasks_file = tmp_path / 'tasks.yml'
+    store = TaskStore(path=tasks_file)
+
+    module = tmp_path / 'myplugin.py'
+    module.write_text(
+        "from task_cascadence.plugins import BaseTask\n"
+        "class MyTask(BaseTask):\n"
+        "    name = 'my'\n"
+        "    def run(self):\n"
+        "        return 'ok'\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    path = 'myplugin:MyTask'
+    store.add_path(path)
+    store.add_path(path)
+
+    assert store.get_paths() == [path]
+    if 'myplugin' in sys.modules:
+        del sys.modules['myplugin']
+
+    tasks = store.load_tasks()
+    assert list(tasks) == ['MyTask']
+    assert isinstance(tasks['MyTask'], plugins.BaseTask)


### PR DESCRIPTION
## Summary
- add tests for TaskStore deduplication and plugin loading

## Testing
- `ruff check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688790b0619c83268dd14d6f533c0554