### PR TITLE
Add broadcast pointer sync tests

### DIFF
--- a/tests/test_pointer_sync.py
+++ b/tests/test_pointer_sync.py
@@ -1,6 +1,9 @@
 import yaml
 from typer.testing import CliRunner
 
+import pytest
+
+from task_cascadence import pointer_sync
 from task_cascadence.pointer_store import PointerStore
 from task_cascadence.cli import app
 from task_cascadence.ume.protos.tasks_pb2 import PointerUpdate
@@ -50,3 +53,51 @@ def test_cli_send_receive(monkeypatch, tmp_path):
     data = yaml.safe_load(store.read_text())
     assert data["demo"][0]["run_id"] == "run1"
     assert data["demo"][0]["user_hash"] == user_hash
+
+
+def test_pointer_sync_broadcast(monkeypatch, tmp_path):
+    store = tmp_path / "pointers.yml"
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(store))
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.setenv("UME_GRPC_METHOD", "Subscribe")
+    monkeypatch.setenv("UME_BROADCAST_POINTERS", "1")
+
+    module = tmp_path / "stub_broadcast.py"
+    module.write_text(
+        """
+class Stub:
+    @staticmethod
+    def Subscribe():
+        from task_cascadence.ume.protos.tasks_pb2 import PointerUpdate
+        return [PointerUpdate(task_name='demo', run_id='b1', user_hash='u')]
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_GRPC_STUB", "stub_broadcast:Stub")
+
+    import importlib
+
+    importlib.invalidate_caches()
+
+    captured = {}
+
+    def fake_emit(update):
+        captured["update"] = update
+
+    monkeypatch.setattr(pointer_sync, "emit_pointer_update", fake_emit)
+
+    pointer_sync.run()
+
+    assert captured["update"].task_name == "demo"
+
+    data = yaml.safe_load(store.read_text())
+    assert data["demo"] == [{"run_id": "b1", "user_hash": "u"}]
+
+
+def test_pointer_sync_incomplete_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(tmp_path / "pointers.yml"))
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.delenv("UME_GRPC_STUB", raising=False)
+
+    with pytest.raises(ValueError):
+        pointer_sync.run()


### PR DESCRIPTION
## Summary
- test broadcast mode of pointer_sync
- ensure service exits with ValueError when config incomplete

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879491f7988326ad0411b21baff708