### PR TITLE
Add IdeaSeed event and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ $ task pause NAME      # pause a task
 $ task resume NAME     # resume a paused task
 $ task schedule NAME CRON  # register a cron schedule
 $ task schedules       # list configured schedules
+$ task ai-idea TEXT    # emit an idea seed via UME
 $ task export-n8n FILE # dump tasks as n8n workflow
 $ task webhook [--host HOST] [--port PORT]  # start webhook server
 $ task watch-plugins DIR # reload plugins on changes in DIR

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -352,6 +352,18 @@ def pointer_sync_cmd() -> None:
     pointer_sync.run()
 
 
+@app.command("ai-idea")
+def ai_idea(text: str, user_id: str | None = typer.Option(None, "--user-id")) -> None:
+    """Send a freeform idea seed via UME."""
+
+    from ..ume import emit_idea_seed
+    from ..ume.models import IdeaSeed
+
+    seed = IdeaSeed(text=text)
+    emit_idea_seed(seed, user_id=user_id)
+    typer.echo("idea sent")
+
+
 @app.command("watch-plugins")  # type: ignore[no-redef]
 def watch_plugins(directory: str = typer.Argument(".")) -> None:  # type: ignore[no-redef]  # noqa: F811
     """Reload plugins when files in ``DIRECTORY`` change."""
@@ -400,5 +412,6 @@ __all__ = [
     "pointer_send",
     "pointer_receive",
     "pointer_sync_cmd",
+    "ai_idea",
 ]
 

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -10,7 +10,7 @@ import hashlib
 from ..config import load_config
 
 from ..transport import BaseTransport, AsyncBaseTransport, get_client
-from .models import TaskRun, TaskSpec, PointerUpdate, TaskNote
+from .models import TaskRun, TaskSpec, PointerUpdate, TaskNote, IdeaSeed
 from ..stage_store import StageStore
 
 
@@ -178,3 +178,24 @@ def emit_task_note(
             _async_queue_within_deadline(note, target)
         )
     return _queue_within_deadline(note, target)
+
+
+def emit_idea_seed(
+    seed: IdeaSeed,
+    client: Any | None = None,
+    user_id: str | None = None,
+    *,
+    use_asyncio: bool = False,
+) -> asyncio.Task | threading.Thread | None:
+    """Emit ``IdeaSeed`` using the configured transport."""
+
+    target = client or _default_client
+    if target is None:
+        raise ValueError("No transport client configured")
+    if user_id is not None:
+        seed.user_hash = _hash_user_id(user_id)
+    if use_asyncio:
+        return asyncio.get_running_loop().create_task(
+            _async_queue_within_deadline(seed, target)
+        )
+    return _queue_within_deadline(seed, target)

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -22,4 +22,15 @@ PointerUpdate = tasks_pb2.PointerUpdate  # type: ignore[attr-defined]
 TaskNote = tasks_pb2.TaskNote  # type: ignore[attr-defined]
 """Generic task note or outcome message."""
 
-__all__ = ["TaskSpec", "TaskRun", "TaskPointer", "PointerUpdate", "TaskNote"]
+
+IdeaSeed = tasks_pb2.IdeaSeed  # type: ignore[attr-defined]
+"""Freeform idea prompt from a user."""
+
+__all__ = [
+    "TaskSpec",
+    "TaskRun",
+    "TaskPointer",
+    "PointerUpdate",
+    "TaskNote",
+    "IdeaSeed",
+]

--- a/task_cascadence/ume/protos/tasks.proto
+++ b/task_cascadence/ume/protos/tasks.proto
@@ -36,3 +36,8 @@ message TaskNote {
   string note = 3;
   string user_hash = 4;
 }
+
+message IdeaSeed {
+  string text = 1;
+  string user_hash = 2;
+}

--- a/task_cascadence/ume/protos/tasks_pb2.py
+++ b/task_cascadence/ume/protos/tasks_pb2.py
@@ -27,7 +27,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btasks.proto\x12\x1atask_cascadence.ume.protos\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n\x08TaskSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"\xd1\x01\n\x07TaskRun\x12\x32\n\x04spec\x18\x01 \x01(\x0b\x32$.task_cascadence.ume.protos.TaskSpec\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12.\n\nstarted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inished_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x11\n\tuser_hash\x18\x06 \x01(\t\"0\n\x0bTaskPointer\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\t\"E\n\rPointerUpdate\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x11\n\tuser_hash\x18\x03 \x01(\t\"N\n\x08TaskNote\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0c\n\x04note\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\tb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btasks.proto\x12\x1atask_cascadence.ume.protos\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n\x08TaskSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"\xd1\x01\n\x07TaskRun\x12\x32\n\x04spec\x18\x01 \x01(\x0b\x32$.task_cascadence.ume.protos.TaskSpec\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12.\n\nstarted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inished_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x11\n\tuser_hash\x18\x06 \x01(\t\"0\n\x0bTaskPointer\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\t\"E\n\rPointerUpdate\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x11\n\tuser_hash\x18\x03 \x01(\t\"N\n\x08TaskNote\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0c\n\x04note\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"+\n\x08IdeaSeed\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\tb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -44,4 +44,6 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_POINTERUPDATE']._serialized_end=485
   _globals['_TASKNOTE']._serialized_start=487
   _globals['_TASKNOTE']._serialized_end=565
+  _globals['_IDEASEED']._serialized_start=567
+  _globals['_IDEASEED']._serialized_end=610
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_user_hash.py
+++ b/tests/test_user_hash.py
@@ -1,8 +1,13 @@
 from datetime import datetime
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from task_cascadence.ume import emit_task_spec, emit_task_run, _hash_user_id
-from task_cascadence.ume.protos.tasks_pb2 import TaskSpec, TaskRun
+from task_cascadence.ume import (
+    emit_task_spec,
+    emit_task_run,
+    emit_idea_seed,
+    _hash_user_id,
+)
+from task_cascadence.ume.protos.tasks_pb2 import TaskSpec, TaskRun, IdeaSeed
 
 
 class Collector:
@@ -40,6 +45,26 @@ def test_run_user_hash_not_raw():
     )
     emit_task_run(run, client, user_id="alice")
     assert client.events[0].user_hash != "alice"
+
+
+def test_idea_seed_user_hash_not_raw():
+    client = Collector()
+    seed = IdeaSeed(text="foo")
+    emit_idea_seed(seed, client, user_id="charlie")
+    assert client.events[0].user_hash != "charlie"
+
+
+def test_idea_seed_hashes_unique():
+    client = Collector()
+    seed1 = IdeaSeed(text="foo")
+    seed2 = IdeaSeed(text="bar")
+    emit_idea_seed(seed1, client, user_id="dave")
+    emit_idea_seed(seed2, client, user_id="eve")
+    h1 = client.events[0].user_hash
+    h2 = client.events[1].user_hash
+    assert h1 != h2
+    assert h1 != "dave"
+    assert h2 != "eve"
 
 
 def test_hash_user_id_secret(monkeypatch):


### PR DESCRIPTION
## Summary
- add `IdeaSeed` protobuf message and regenerate bindings
- expose `IdeaSeed` from UME models and add `emit_idea_seed`
- add `ai-idea` CLI command
- document CLI usage
- test new IdeaSeed emission and hashing

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879b36cd8c832692ba8316b4350db3