### PR TITLE
Add IdeaSeed listing to dashboard

### DIFF
--- a/task_cascadence/idea_store.py
+++ b/task_cascadence/idea_store.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Any, Dict, List
+
+import yaml
+
+from .config import load_config
+from .ume.models import IdeaSeed
+
+
+class IdeaStore:
+    """Persistent store for :class:`IdeaSeed` objects."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_IDEAS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("ideas_path")
+        if path is None:
+            path = Path.home() / ".cascadence" / "ideas.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: List[Dict[str, Any]] = self._load()
+
+    def _load(self) -> List[Dict[str, Any]]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or []
+                if isinstance(data, list):
+                    return data
+        return []
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_seed(self, seed: IdeaSeed) -> None:
+        entry = {"text": seed.text}
+        user_hash = getattr(seed, "user_hash", None)
+        if user_hash:
+            entry["user_hash"] = user_hash
+        self._data.append(entry)
+        self._save()
+
+    def get_seeds(self) -> List[Dict[str, Any]]:
+        return list(self._data)
+
+__all__ = ["IdeaStore"]

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -12,10 +12,12 @@ from ..config import load_config
 from ..transport import BaseTransport, AsyncBaseTransport, get_client
 from .models import TaskRun, TaskSpec, PointerUpdate, TaskNote, IdeaSeed
 from ..stage_store import StageStore
+from ..idea_store import IdeaStore
 
 
 _default_client: BaseTransport | AsyncBaseTransport | None = None
 _stage_store: StageStore | None = None
+_idea_store: IdeaStore | None = None
 
 
 def _hash_user_id(user_id: str) -> str:
@@ -28,6 +30,13 @@ def _get_stage_store() -> StageStore:
     if _stage_store is None:
         _stage_store = StageStore()
     return _stage_store
+
+
+def _get_idea_store() -> IdeaStore:
+    global _idea_store
+    if _idea_store is None:
+        _idea_store = IdeaStore()
+    return _idea_store
 
 
 def emit_stage_update(task_name: str, stage: str, user_id: str | None = None) -> None:
@@ -194,6 +203,7 @@ def emit_idea_seed(
         raise ValueError("No transport client configured")
     if user_id is not None:
         seed.user_hash = _hash_user_id(user_id)
+    _get_idea_store().add_seed(seed)
     if use_asyncio:
         return asyncio.get_running_loop().create_task(
             _async_queue_within_deadline(seed, target)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,9 @@
 from fastapi.testclient import TestClient
 
-from task_cascadence.dashboard import app, StageStore, PointerStore
+from task_cascadence.dashboard import app, StageStore, PointerStore, IdeaStore
 from task_cascadence.scheduler import BaseScheduler
 from task_cascadence.plugins import ExampleTask, PointerTask
+from task_cascadence.ume.models import IdeaSeed
 
 
 def setup(monkeypatch, tmp_path):
@@ -100,4 +101,18 @@ def test_dashboard_async_mode(monkeypatch, tmp_path):
 
     assert resp.status_code == 200
     assert "<td>async</td>" in resp.text
+
+
+def test_dashboard_idea_seeds(monkeypatch, tmp_path):
+    sched, _, _ = setup(monkeypatch, tmp_path)
+    idea_store = IdeaStore(path=tmp_path / "ideas.yml")
+    idea_store.add_seed(IdeaSeed(text="bright"))
+    monkeypatch.setattr("task_cascadence.dashboard.IdeaStore", lambda: idea_store)
+
+    client = TestClient(app)
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    assert "bright" in resp.text
+    assert "Promote" in resp.text
 


### PR DESCRIPTION
## Summary
- show IdeaSeeds on dashboard and add promote form
- persist IdeaSeeds locally
- store IdeaSeeds when emitted
- cover IdeaSeed rendering on dashboard

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879e666a088326932aca3562227bb1