### PR TITLE
Add capability planner service

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,19 @@ The service reads the same ``UME_*`` environment variables used for event
 emission and persists incoming :class:`PointerUpdate` messages via
 ``PointerStore.apply_update``.
 
+## Capability Planner
+
+The :mod:`task_cascadence.capability_planner` module watches UME for
+``TaskRun`` events with ``status='error'``. When a failure is detected a
+placeholder follow-up task is scheduled via the default scheduler.
+
+Start the service directly or via the CLI:
+
+```bash
+$ python -m task_cascadence.capability_planner
+$ task capability-planner
+```
+
 ## n8n Export
 
 Tasks registered with Cascadence can be exported as an n8n workflow using the

--- a/task_cascadence/capability_planner.py
+++ b/task_cascadence/capability_planner.py
@@ -1,0 +1,90 @@
+"""Plan follow-up actions based on failed task runs."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Iterable, Any
+
+from .config import load_config
+from .scheduler import get_default_scheduler
+from .ume.models import TaskRun
+from .plugins import CronTask
+
+logger = logging.getLogger(__name__)
+
+
+class _FollowUpTask(CronTask):
+    """Placeholder task scheduled for failed runs."""
+
+    name = "capability_follow_up"
+
+    def run(self):  # pragma: no cover - trivial demo
+        pass
+
+
+def _import_object(path: str) -> Any:
+    module, attr = path.split(":")
+    mod = importlib.import_module(module)
+    return getattr(mod, attr)
+
+
+def run() -> None:
+    """Watch UME for ``TaskRun`` events with ``status='error'``."""
+
+    cfg = load_config()
+    transport = cfg.get("ume_transport")
+    sched = get_default_scheduler()
+
+    if not transport:
+        print("UME transport not configured. Exiting.")
+        return
+
+    def _schedule_follow_up() -> None:
+        try:
+            sched.register_task(_FollowUpTask.name, _FollowUpTask())
+        except Exception:  # pragma: no cover - resilient loop
+            logger.exception("Error scheduling follow-up task")
+
+    if transport == "grpc":
+        if not cfg.get("ume_grpc_stub"):
+            raise ValueError("UME_GRPC_STUB not configured")
+        stub = _import_object(cfg["ume_grpc_stub"])
+        method = cfg.get("ume_grpc_method", "Subscribe")
+        listener = getattr(stub, method)()
+        for event in listener:
+            try:
+                if getattr(event, "status", "") == "error":
+                    _schedule_follow_up()
+            except Exception:  # pragma: no cover - resilient loop
+                logger.exception("Error processing run event")
+                continue
+        return
+
+    if transport == "nats":
+        if not cfg.get("ume_nats_conn"):
+            raise ValueError("UME_NATS_CONN not configured")
+        conn = _import_object(cfg["ume_nats_conn"])
+        subject = cfg.get("ume_nats_subject", "events")
+        subscription: Iterable[Any] = conn.subscribe_sync(subject)
+        for msg in subscription:
+            try:
+                data = getattr(msg, "data", msg)
+                event = TaskRun()
+                if isinstance(data, TaskRun):
+                    event = data
+                else:
+                    event.ParseFromString(data)
+                if event.status == "error":
+                    _schedule_follow_up()
+            except Exception:  # pragma: no cover - resilient loop
+                logger.exception("Error processing run event")
+                continue
+        return
+
+    print(f"Unknown UME transport: {transport}. Exiting.")
+    return
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run()

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -352,6 +352,15 @@ def pointer_sync_cmd() -> None:
     pointer_sync.run()
 
 
+@app.command("capability-planner")
+def capability_planner_cmd() -> None:
+    """Start the capability planner service."""
+
+    from .. import capability_planner
+
+    capability_planner.run()
+
+
 @app.command("ai-idea")
 def ai_idea(text: str, user_id: str | None = typer.Option(None, "--user-id")) -> None:
     """Send a freeform idea seed via UME."""
@@ -412,6 +421,7 @@ __all__ = [
     "pointer_send",
     "pointer_receive",
     "pointer_sync_cmd",
+    "capability_planner_cmd",
     "ai_idea",
 ]
 

--- a/tests/test_capability_planner.py
+++ b/tests/test_capability_planner.py
@@ -1,0 +1,93 @@
+from typer.testing import CliRunner
+import importlib
+
+from task_cascadence.cli import app
+from task_cascadence import capability_planner
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.tasks = []
+
+    def register_task(self, name, task):
+        self.tasks.append(name)
+
+
+def test_capability_planner_grpc(monkeypatch, tmp_path):
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.setenv("UME_GRPC_METHOD", "Subscribe")
+
+    module = tmp_path / "stub_planner.py"
+    module.write_text(
+        """
+class Stub:
+    @staticmethod
+    def Subscribe():
+        from task_cascadence.ume.protos.tasks_pb2 import TaskRun, TaskSpec
+        return [TaskRun(spec=TaskSpec(id='demo', name='demo'), run_id='r1', status='error')]
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_GRPC_STUB", "stub_planner:Stub")
+
+    importlib.invalidate_caches()
+    sched = DummyScheduler()
+    monkeypatch.setattr(capability_planner, "get_default_scheduler", lambda: sched)
+
+    capability_planner.run()
+
+    assert sched.tasks == ["capability_follow_up"]
+
+
+def test_capability_planner_nats(monkeypatch, tmp_path):
+    monkeypatch.setenv("UME_TRANSPORT", "nats")
+
+    module = tmp_path / "conn_planner.py"
+    module.write_text(
+        """
+class Conn:
+    def subscribe_sync(self, subject):
+        from task_cascadence.ume.protos.tasks_pb2 import TaskRun, TaskSpec
+        run = TaskRun(spec=TaskSpec(id='demo', name='demo'), run_id='r2', status='error')
+        return [run.SerializeToString()]
+conn = Conn()
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_NATS_CONN", "conn_planner:conn")
+    monkeypatch.setenv("UME_NATS_SUBJECT", "events")
+
+    importlib.invalidate_caches()
+    sched = DummyScheduler()
+    monkeypatch.setattr(capability_planner, "get_default_scheduler", lambda: sched)
+
+    capability_planner.run()
+
+    assert sched.tasks == ["capability_follow_up"]
+
+
+def test_cli_capability_planner(monkeypatch, tmp_path):
+    monkeypatch.setenv("UME_TRANSPORT", "grpc")
+    monkeypatch.setenv("UME_GRPC_METHOD", "Subscribe")
+
+    module = tmp_path / "stub_cli_planner.py"
+    module.write_text(
+        """
+class Stub:
+    @staticmethod
+    def Subscribe():
+        from task_cascadence.ume.protos.tasks_pb2 import TaskRun, TaskSpec
+        return [TaskRun(spec=TaskSpec(id='demo', name='demo'), run_id='cli', status='error')]
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("UME_GRPC_STUB", "stub_cli_planner:Stub")
+
+    importlib.invalidate_caches()
+    sched = DummyScheduler()
+    monkeypatch.setattr(capability_planner, "get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["capability-planner"])
+    assert result.exit_code == 0
+    assert sched.tasks == ["capability_follow_up"]


### PR DESCRIPTION
## Summary
- add new capability_planner service module
- expose `task capability-planner` command
- create tests for planner service
- document capability planner usage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879e65bc6c8326b6e25bc0c0ed6fae