### PR TITLE
Add StageUpdate transport emission

### DIFF
--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from .ume import emit_task_spec, emit_task_run, emit_stage_update
+from .ume import emit_task_spec, emit_task_run, emit_stage_update_event
 from .ume.models import TaskRun, TaskSpec
 from . import research
 import time
@@ -50,7 +50,9 @@ class TaskPipeline:
             description=stage,
         )
         emit_task_spec(spec, user_id=user_id)
-        emit_stage_update(self.task.__class__.__name__, stage, user_id=user_id)
+        emit_stage_update_event(
+            self.task.__class__.__name__, stage, user_id=user_id
+        )
 
     def intake(self, *, user_id: str | None = None) -> None:
         if hasattr(self.task, "intake"):
@@ -191,7 +193,9 @@ class TaskPipeline:
             else:
                 result = self._call_run(plan_result)
 
-            emit_stage_update(self.task.__class__.__name__, "run", user_id=user_id)
+            emit_stage_update_event(
+                self.task.__class__.__name__, "run", user_id=user_id
+            )
         except Exception:
             status = "error"
             raise
@@ -222,12 +226,16 @@ class TaskPipeline:
     def pause(self, *, user_id: str | None = None) -> None:
         """Pause execution of this pipeline."""
         self._paused = True
-        emit_stage_update(self.task.__class__.__name__, "paused", user_id=user_id)
+        emit_stage_update_event(
+            self.task.__class__.__name__, "paused", user_id=user_id
+        )
 
     def resume(self, *, user_id: str | None = None) -> None:
         """Resume a previously paused pipeline."""
         self._paused = False
-        emit_stage_update(self.task.__class__.__name__, "resumed", user_id=user_id)
+        emit_stage_update_event(
+            self.task.__class__.__name__, "resumed", user_id=user_id
+        )
 
     def _wait_if_paused(self) -> None:
         while self._paused:

--- a/task_cascadence/ume/models.py
+++ b/task_cascadence/ume/models.py
@@ -26,6 +26,9 @@ TaskNote = tasks_pb2.TaskNote  # type: ignore[attr-defined]
 IdeaSeed = tasks_pb2.IdeaSeed  # type: ignore[attr-defined]
 """Freeform idea prompt from a user."""
 
+StageUpdate = tasks_pb2.StageUpdate  # type: ignore[attr-defined]
+"""Pipeline stage change message."""
+
 __all__ = [
     "TaskSpec",
     "TaskRun",
@@ -33,4 +36,5 @@ __all__ = [
     "PointerUpdate",
     "TaskNote",
     "IdeaSeed",
+    "StageUpdate",
 ]

--- a/task_cascadence/ume/protos/tasks.proto
+++ b/task_cascadence/ume/protos/tasks.proto
@@ -41,3 +41,9 @@ message IdeaSeed {
   string text = 1;
   string user_hash = 2;
 }
+
+message StageUpdate {
+  string task_name = 1;
+  string stage = 2;
+  string user_hash = 3;
+}

--- a/task_cascadence/ume/protos/tasks_pb2.py
+++ b/task_cascadence/ume/protos/tasks_pb2.py
@@ -27,7 +27,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btasks.proto\x12\x1atask_cascadence.ume.protos\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n\x08TaskSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"\xd1\x01\n\x07TaskRun\x12\x32\n\x04spec\x18\x01 \x01(\x0b\x32$.task_cascadence.ume.protos.TaskSpec\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12.\n\nstarted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inished_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x11\n\tuser_hash\x18\x06 \x01(\t\"0\n\x0bTaskPointer\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\t\"E\n\rPointerUpdate\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x11\n\tuser_hash\x18\x03 \x01(\t\"N\n\x08TaskNote\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0c\n\x04note\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"+\n\x08IdeaSeed\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\tb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btasks.proto\x12\x1atask_cascadence.ume.protos\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n\x08TaskSpec\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"\xd1\x01\n\x07TaskRun\x12\x32\n\x04spec\x18\x01 \x01(\x0b\x32$.task_cascadence.ume.protos.TaskSpec\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12.\n\nstarted_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x0b\x66inished_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x11\n\tuser_hash\x18\x06 \x01(\t\"0\n\x0bTaskPointer\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\t\"E\n\rPointerUpdate\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x11\n\tuser_hash\x18\x03 \x01(\t\"N\n\x08TaskNote\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x0c\n\x04note\x18\x03 \x01(\t\x12\x11\n\tuser_hash\x18\x04 \x01(\t\"+\n\x08IdeaSeed\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x11\n\tuser_hash\x18\x02 \x01(\t\"B\n\x0bStageUpdate\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\r\n\x05stage\x18\x02 \x01(\t\x12\x11\n\tuser_hash\x18\x03 \x01(\tb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -46,4 +46,6 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_TASKNOTE']._serialized_end=565
   _globals['_IDEASEED']._serialized_start=567
   _globals['_IDEASEED']._serialized_end=610
+  _globals['_STAGEUPDATE']._serialized_start=612
+  _globals['_STAGEUPDATE']._serialized_end=678
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -6,7 +6,7 @@ from task_cascadence.cli import app
 from task_cascadence.scheduler import BaseScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.ume import _hash_user_id, emit_task_note, emit_idea_seed
-from task_cascadence.ume.models import TaskNote, IdeaSeed
+from task_cascadence.ume.models import TaskNote, IdeaSeed, StageUpdate
 
 
 class DemoTask:
@@ -114,3 +114,31 @@ def test_emit_idea_seed(monkeypatch):
     serialized = client.events[0].SerializeToString()
     again = IdeaSeed.FromString(serialized)
     assert again == client.events[0]
+
+
+def test_emit_stage_update_event(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+
+    class Client:
+        def __init__(self):
+            self.events = []
+
+        def enqueue(self, obj):
+            self.events.append(obj)
+
+    client = Client()
+
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+
+    ume.emit_stage_update_event("demo", "start", client, user_id="alice")
+
+    assert isinstance(client.events[0], StageUpdate)
+    assert client.events[0].user_hash == _hash_user_id("alice")
+    serialized = client.events[0].SerializeToString()
+    again = StageUpdate.FromString(serialized)
+    assert again == client.events[0]
+
+    data = yaml.safe_load((tmp_path / "stages.yml").read_text())
+    assert data["demo"][0]["user_hash"] == _hash_user_id("alice")


### PR DESCRIPTION
## Summary
- extend task protos with `StageUpdate`
- emit `StageUpdate` transport events in `ume`
- use new helper in `TaskPipeline`
- test hashed `StageUpdate` events

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c618bdf48326a0d1c21fe785a0ad