### PR TITLE
Add timezone configuration support

### DIFF
--- a/task_cascadence/__init__.py
+++ b/task_cascadence/__init__.py
@@ -28,7 +28,8 @@ def initialize() -> None:
     store = TaskStore()
     loaded = store.load_tasks()
     backend = cfg.get("backend", cfg.get("scheduler", "cron"))
-    sched = create_scheduler(backend, tasks=loaded)
+    timezone = cfg.get("timezone", "UTC")
+    sched = create_scheduler(backend, tasks=loaded, timezone=timezone)
     set_default_scheduler(sched)
     for task in loaded.values():
         if task.name not in sched._tasks:

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -29,6 +29,9 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     )
     cfg["backend"] = backend
 
+    timezone = os.getenv("CASCADENCE_TIMEZONE", cfg.get("timezone", "UTC"))
+    cfg["timezone"] = timezone
+
     refresh_env = os.getenv("CASCADENCE_CRONYX_REFRESH")
     if refresh_env is not None:
         cfg["cronyx_refresh"] = refresh_env.lower() not in ("0", "false", "no")

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -223,7 +223,9 @@ def reload_plugins() -> None:
     cfg = load_config()
     store = TaskStore()
     tasks = store.load_tasks()
-    sched = _scheduler.create_scheduler(cfg["backend"], tasks=tasks)
+    sched = _scheduler.create_scheduler(
+        cfg["backend"], tasks=tasks, timezone=cfg.get("timezone", "UTC")
+    )
     _scheduler.set_default_scheduler(sched)
     for task in tasks.values():
         if task.name not in sched._tasks:

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -418,12 +418,17 @@ def get_default_scheduler() -> BaseScheduler:
 default_scheduler = get_default_scheduler
 
 
-def create_scheduler(backend: str, tasks: dict[str, Any] | None = None) -> BaseScheduler:
+def create_scheduler(
+    backend: str,
+    tasks: dict[str, Any] | None = None,
+    *,
+    timezone: str | ZoneInfo = "UTC",
+) -> BaseScheduler:
     """Factory returning a scheduler for ``backend``."""
 
     tasks = tasks or {}
     if backend == "cron":
-        return CronScheduler(tasks=tasks)
+        return CronScheduler(timezone=timezone, tasks=tasks)
     if backend == "base":
         return BaseScheduler()
     if backend == "temporal":
@@ -433,7 +438,7 @@ def create_scheduler(backend: str, tasks: dict[str, Any] | None = None) -> BaseS
         return CronyxScheduler()
     if backend == "dag":
         from .dag import DagCronScheduler
-        return DagCronScheduler(tasks=tasks)
+        return DagCronScheduler(timezone=timezone, tasks=tasks)
     raise ValueError(f"Unknown scheduler backend: {backend}")
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -8,6 +8,34 @@ from task_cascadence.scheduler import TemporalScheduler
 from task_cascadence.config import load_config
 
 
+def test_yaml_timezone(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("timezone: Europe/Paris")
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
+    monkeypatch.delenv("CASCADENCE_TIMEZONE", raising=False)
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    from zoneinfo import ZoneInfo
+
+    sched = get_default_scheduler()
+    assert str(sched.scheduler.timezone) == "Europe/Paris"
+    assert isinstance(sched.scheduler.timezone, ZoneInfo)
+
+
+def test_env_overrides_yaml_timezone(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("timezone: Europe/Paris")
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
+    monkeypatch.setenv("CASCADENCE_TIMEZONE", "Asia/Tokyo")
+    importlib.reload(task_cascadence)
+    task_cascadence.initialize()
+    from zoneinfo import ZoneInfo
+
+    sched = get_default_scheduler()
+    assert str(sched.scheduler.timezone) == "Asia/Tokyo"
+    assert isinstance(sched.scheduler.timezone, ZoneInfo)
+
+
 def test_env_selects_base_scheduler(monkeypatch):
     monkeypatch.setenv("CASCADENCE_SCHEDULER", "base")
     importlib.reload(task_cascadence)


### PR DESCRIPTION
## Summary
- allow timezone to be configured via YAML or `CASCADENCE_TIMEZONE`
- propagate timezone into scheduler creation in `initialize` and plugin reloads
- pass timezone to `create_scheduler`
- test environment timezone handling
- verify timezone configuration from YAML and env override

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c6177ac483268143a06d92f9e47a