### PR TITLE
Add asyncio pointer-sync

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -370,8 +370,17 @@ def pointer_sync_cmd() -> None:
     """Start the pointer synchronization service."""
 
     from .. import pointer_sync
+    import asyncio
 
-    pointer_sync.run()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        loop.create_task(pointer_sync.run_async())
+    else:
+        pointer_sync.run()
 
 
 @app.command("capability-planner")


### PR DESCRIPTION
## Summary
- add async `run_async` entry point for pointer synchronization
- use asyncio broadcast helpers and support both sync and async listeners
- update CLI to call async version when running inside a loop
- test async pointer-sync behaviour for gRPC and NATS

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887eb174f6883269437551765d3a239