### PR TITLE
Await verify result if coroutine

### DIFF
--- a/tests/test_async_verify.py
+++ b/tests/test_async_verify.py
@@ -1,0 +1,19 @@
+import asyncio
+from task_cascadence.orchestrator import TaskPipeline
+
+
+class DemoTask:
+    def run(self):
+        return "ok"
+
+    async def verify(self, result):
+        await asyncio.sleep(0)
+        return f"verified-{result}"
+
+
+def test_async_verify(monkeypatch):
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    pipeline = TaskPipeline(DemoTask())
+    result = pipeline.run()
+    assert result == "verified-ok"


### PR DESCRIPTION
## Summary
- await verification results if the verify method returns a coroutine
- add a regression test for async verify

## Testing
- `ruff check task_cascadence tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889509691708326a9968afb2db61725