### PR TITLE
Improve pointer sync typing

### DIFF
--- a/task_cascadence/pointer_sync.py
+++ b/task_cascadence/pointer_sync.py
@@ -9,7 +9,7 @@ import asyncio
 import importlib
 import inspect
 import logging
-from typing import Iterable, Any
+from typing import Iterable, Any, AsyncIterator
 
 from .config import load_config
 from .pointer_store import PointerStore
@@ -61,7 +61,7 @@ async def run_async() -> None:
         if hasattr(listener, "__aiter__"):
             async_iter = listener
         else:
-            async def _gen():
+            async def _gen() -> AsyncIterator[Any]:
                 for item in listener:
                     yield item
             async_iter = _gen()
@@ -88,7 +88,7 @@ async def run_async() -> None:
         if hasattr(subscription, "__aiter__"):
             async_iter = subscription
         else:
-            async def _gen():
+            async def _gen() -> AsyncIterator[Any]:
                 for item in subscription:
                     yield item
             async_iter = _gen()


### PR DESCRIPTION
## Summary
- add missing annotations for internal generator functions in `pointer_sync`
- ensure project passes typing checks

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a252896dc8326ab1e5ccc1c882198