### PR TITLE
Gracefully restart scheduler on plugin reload

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -213,6 +213,13 @@ def reload_plugins() -> None:
     from ..config import load_config
     from ..task_store import TaskStore
 
+    old_sched = getattr(_scheduler, "_default_scheduler", None)
+    if old_sched and hasattr(old_sched, "shutdown"):
+        try:  # pragma: no cover - best effort cleanup
+            old_sched.shutdown(wait=False)
+        except Exception:
+            pass
+
     for task in registered_tasks.values():
         mod = task.__class__.__module__
         if mod != __name__ and mod in sys.modules:


### PR DESCRIPTION
## Summary
- shut down old scheduler in `reload_plugins`
- test plugin reload restores schedules once

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad0541df08326867c1b9e0a64518c