### PR TITLE
Add ai_plan fallback test

### DIFF
--- a/tests/test_ai_plan.py
+++ b/tests/test_ai_plan.py
@@ -1,0 +1,20 @@
+import types
+from unittest.mock import Mock
+from task_cascadence.orchestrator import TaskPipeline
+
+
+def test_ai_plan_module_used(monkeypatch):
+    mock_ai_plan = types.SimpleNamespace(plan=Mock(return_value="auto"))
+    monkeypatch.setattr("task_cascadence.orchestrator.ai_plan", mock_ai_plan)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+
+    class DemoTask:
+        def run(self, plan: str) -> str:
+            return plan
+
+    task = DemoTask()
+    result = TaskPipeline(task).run()
+
+    assert result == "auto"
+    mock_ai_plan.plan.assert_called_once_with(task)


### PR DESCRIPTION
## Summary
- add regression test for using `ai_plan.plan` when tasks don't define a `plan`

## Testing
- `ruff check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad8a5fddc83269a9a06fb82193b71