### PR TITLE
Replace prints with logging

### DIFF
--- a/task_cascadence/capability_planner.py
+++ b/task_cascadence/capability_planner.py
@@ -37,7 +37,7 @@ def run() -> None:
     sched = get_default_scheduler()
 
     if not transport:
-        print("UME transport not configured. Exiting.")
+        logger.warning("UME transport not configured. Exiting.")
         return
 
     def _schedule_follow_up() -> None:
@@ -82,7 +82,7 @@ def run() -> None:
                 continue
         return
 
-    print(f"Unknown UME transport: {transport}. Exiting.")
+    logger.warning("Unknown UME transport: %s. Exiting.", transport)
     return
 
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -6,6 +6,7 @@ complex projects could load plugins dynamically using entry points.
 """
 
 import importlib
+import logging
 import sys
 from importlib import metadata
 from typing import Dict
@@ -16,6 +17,8 @@ from ..pointer_store import PointerStore
 
 from ..scheduler import get_default_scheduler
 
+logger = logging.getLogger(__name__)
+
 
 class BaseTask:
     """Base class for all tasks."""
@@ -25,7 +28,7 @@ class BaseTask:
     def run(self):  # pragma: no cover - trivial demo function
         """Run the task."""
 
-        print(f"running task {self.name}")
+        logger.info("running task %s", self.name)
 
 
 class CronTask(BaseTask):
@@ -90,7 +93,7 @@ class ExampleTask(CronTask):
     name = "example"
 
     def run(self):  # pragma: no cover - illustrative
-        print("Example task executed")
+        logger.info("Example task executed")
 
 
 @register_webhook_task

--- a/task_cascadence/pointer_sync.py
+++ b/task_cascadence/pointer_sync.py
@@ -34,7 +34,7 @@ async def run_async() -> None:
     broadcast = bool(cfg.get("ume_broadcast_pointers"))
 
     if not transport:
-        print("UME transport not configured. Exiting.")
+        logger.warning("UME transport not configured. Exiting.")
         return
 
     async def _maybe_broadcast(update: PointerUpdate) -> None:
@@ -107,7 +107,7 @@ async def run_async() -> None:
                 continue
         return
 
-    print(f"Unknown UME transport: {transport}. Exiting.")
+    logger.warning("Unknown UME transport: %s. Exiting.", transport)
     return
 
 


### PR DESCRIPTION
## Summary
- replace prints with logger calls in pointer sync and capability planner
- use logger in example plugins
- check for log messages in capability planner tests
- check for log messages in pointer sync service tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c101ec3f08326a097324ee9c01ad3