### PR TITLE
Add thread safety to pipeline registry

### DIFF
--- a/task_cascadence/pipeline_registry.py
+++ b/task_cascadence/pipeline_registry.py
@@ -3,21 +3,26 @@
 from __future__ import annotations
 
 from typing import Dict, Optional
+from threading import Lock
 
 from .orchestrator import TaskPipeline
 
 # Running pipelines keyed by task name
 _running_pipelines: Dict[str, TaskPipeline] = {}
+# Lock protecting access to the running pipeline registry
+_registry_lock = Lock()
 
 
 def add_pipeline(name: str, pipeline: TaskPipeline) -> None:
     """Register *pipeline* under *name*."""
-    _running_pipelines[name] = pipeline
+    with _registry_lock:
+        _running_pipelines[name] = pipeline
 
 
 def remove_pipeline(name: str) -> None:
     """Remove the pipeline registered as *name* if present."""
-    _running_pipelines.pop(name, None)
+    with _registry_lock:
+        _running_pipelines.pop(name, None)
 
 
 def get_pipeline(name: str) -> Optional[TaskPipeline]:
@@ -27,4 +32,5 @@ def get_pipeline(name: str) -> Optional[TaskPipeline]:
 
 def list_pipelines() -> Dict[str, TaskPipeline]:
     """Return a copy of the currently registered pipelines."""
-    return dict(_running_pipelines)
+    with _registry_lock:
+        return dict(_running_pipelines)

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -1,0 +1,45 @@
+import threading
+import time
+from task_cascadence.pipeline_registry import add_pipeline, remove_pipeline, list_pipelines
+from task_cascadence.orchestrator import TaskPipeline
+from task_cascadence.plugins import ExampleTask
+
+
+def test_thread_safe_registry():
+    pipeline = TaskPipeline(ExampleTask())
+    errors: list[Exception] = []
+    stop_event = threading.Event()
+
+    def add_remove_worker(worker_id: int) -> None:
+        # Add and remove multiple pipelines
+        for i in range(100):
+            name = f"p{worker_id}_{i}"
+            add_pipeline(name, pipeline)
+            time.sleep(0.001)
+            remove_pipeline(name)
+        if worker_id == 0:
+            stop_event.set()
+
+    def list_worker() -> None:
+        # Continuously list pipelines while other threads modify registry
+        while not stop_event.is_set():
+            try:
+                list_pipelines()
+            except Exception as exc:  # pragma: no cover - failure information
+                errors.append(exc)
+
+    add_thread = threading.Thread(target=add_remove_worker, args=(0,))
+    add_thread2 = threading.Thread(target=add_remove_worker, args=(1,))
+    list_thread = threading.Thread(target=list_worker)
+
+    add_thread.start()
+    add_thread2.start()
+    list_thread.start()
+
+    add_thread.join()
+    add_thread2.join()
+    stop_event.set()
+    list_thread.join()
+
+    assert not errors
+    assert list_pipelines() == {}


### PR DESCRIPTION
## Summary
- add a lock to `pipeline_registry` to protect concurrent access
- guard registry operations with the lock
- add a multithreaded test covering the registry

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc24253b48326bb4834a78586a115