### PR TITLE
Add coverage for research gather, transport clients, and DAG scheduler

### DIFF
--- a/tests/test_dag_dependencies.py
+++ b/tests/test_dag_dependencies.py
@@ -1,0 +1,80 @@
+from task_cascadence.scheduler.dag import DagCronScheduler
+from task_cascadence.plugins import CronTask
+import pytest
+import yaml
+
+
+class TaskA(CronTask):
+    def __init__(self, log):
+        self.log = log
+
+    def run(self):
+        self.log.append("A")
+
+
+class TaskB(CronTask):
+    def __init__(self, log):
+        self.log = log
+
+    def run(self):
+        self.log.append("B")
+
+
+class TaskC(CronTask):
+    def __init__(self, log):
+        self.log = log
+
+    def run(self):
+        self.log.append("C")
+
+
+def test_dependency_deduplication(tmp_path, monkeypatch):
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+    log = []
+    sched = DagCronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    a = TaskA(log)
+    b = TaskB(log)
+    c = TaskC(log)
+    sched.register_task(c, "* * * * *")
+    sched.register_task(b, "* * * * *", dependencies=["TaskC"])
+    sched.register_task(a, "* * * * *", dependencies=["TaskB", "TaskC"])
+
+    sched.run_task("TaskA")
+
+    assert log == ["C", "B", "A"]
+
+
+def test_register_by_name_and_unschedule(tmp_path, monkeypatch):
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+    log = []
+    sched = DagCronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    t = TaskA(log)
+    sched.register_task("custom", t, dependencies=["TaskA"], user_id="u1")
+    assert sched.dependencies["custom"] == ["TaskA"]
+    assert "custom" not in sched.schedules
+    with pytest.raises(ValueError):
+        sched.unschedule("custom")
+
+
+def test_wrap_task_paused(tmp_path, monkeypatch):
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+    log = []
+    sched = DagCronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    t = TaskA(log)
+    sched.register_task(t, "* * * * *")
+    sched.pause_task("TaskA")
+    runner = sched._wrap_task(t)
+    runner()
+    assert log == []
+    sched.resume_task("TaskA")
+    runner()
+    assert log == ["A"]
+
+
+def test_restore_skips_unknown_tasks(tmp_path):
+    data = {"TaskA": "* * * * *", "Missing": "* * * * *"}
+    path = tmp_path / "s.yml"
+    yaml.safe_dump(data, path.open("w"))
+    t = TaskA([])
+    sched = DagCronScheduler(timezone="UTC", storage_path=path, tasks={"TaskA": t})
+    assert "Missing" not in sched.dependencies

--- a/tests/test_research_gather.py
+++ b/tests/test_research_gather.py
@@ -1,0 +1,54 @@
+import asyncio
+import pytest
+
+import task_cascadence.research as research
+
+
+def test_gather_with_search(monkeypatch):
+    class Stub:
+        def search(self, query):
+            return f"result:{query}"
+
+    monkeypatch.setattr(research, "tino_storm", Stub())
+    assert research.gather("foo") == "result:foo"
+
+
+def test_gather_with_callable(monkeypatch):
+    def func(query):
+        return f"call:{query}"
+
+    monkeypatch.setattr(research, "tino_storm", func)
+    assert research.gather("bar") == "call:bar"
+
+
+def test_gather_invalid_interface(monkeypatch):
+    monkeypatch.setattr(research, "tino_storm", object())
+    with pytest.raises(RuntimeError):
+        research.gather("oops")
+
+
+def test_async_gather_search_returns_coroutine(monkeypatch):
+    class Stub:
+        async def search(self, query):
+            await asyncio.sleep(0)
+            return f"async:{query}"
+
+    monkeypatch.setattr(research, "tino_storm", Stub())
+    result = asyncio.run(research.async_gather("abc"))
+    assert result == "async:abc"
+
+
+def test_async_gather_callable_returns_coroutine(monkeypatch):
+    async def func(query):
+        await asyncio.sleep(0)
+        return f"coro:{query}"
+
+    monkeypatch.setattr(research, "tino_storm", func)
+    result = asyncio.run(research.async_gather("xyz"))
+    assert result == "coro:xyz"
+
+
+def test_async_gather_invalid_interface(monkeypatch):
+    monkeypatch.setattr(research, "tino_storm", object())
+    with pytest.raises(RuntimeError):
+        asyncio.run(research.async_gather("fail"))

--- a/tests/test_transport_clients.py
+++ b/tests/test_transport_clients.py
@@ -1,0 +1,91 @@
+import asyncio
+import pytest
+
+from task_cascadence.transport import (
+    BaseTransport,
+    AsyncBaseTransport,
+    GrpcClient,
+    NatsClient,
+    AsyncGrpcClient,
+    AsyncNatsClient,
+    get_client,
+)
+
+
+class DummyStub:
+    def __init__(self):
+        self.called = []
+
+    def Send(self, msg, timeout=None):
+        self.called.append((msg, timeout))
+
+
+class DummyAsyncStub:
+    def __init__(self):
+        self.called = []
+
+    async def Send(self, msg, timeout=None):
+        self.called.append((msg, timeout))
+
+
+class DummyConn:
+    def __init__(self):
+        self.actions = []
+
+    def publish(self, subject, msg):
+        self.actions.append(("pub", subject, msg))
+
+    def flush(self, timeout=0):
+        self.actions.append(("flush", timeout))
+
+
+class DummyAsyncConn:
+    def __init__(self):
+        self.actions = []
+
+    async def publish(self, subject, msg):
+        self.actions.append(("pub", subject, msg))
+
+    async def flush(self, timeout=0):
+        self.actions.append(("flush", timeout))
+
+
+def test_base_transport_not_implemented():
+    with pytest.raises(NotImplementedError):
+        BaseTransport().enqueue("x")
+
+
+def test_async_base_transport_not_implemented():
+    with pytest.raises(NotImplementedError):
+        asyncio.run(AsyncBaseTransport().enqueue("x"))
+
+
+def test_get_client_types():
+    assert isinstance(get_client("grpc", stub=DummyStub()), GrpcClient)
+    assert isinstance(get_client("nats", connection=DummyConn()), NatsClient)
+    assert isinstance(get_client("grpc_async", stub=DummyAsyncStub()), AsyncGrpcClient)
+    assert isinstance(get_client("nats_async", connection=DummyAsyncConn()), AsyncNatsClient)
+    with pytest.raises(ValueError):
+        get_client("unknown")
+
+
+def test_grpc_and_nats_clients():
+    stub = DummyStub()
+    conn = DummyConn()
+    g = GrpcClient(stub)
+    n = NatsClient(conn, subject="demo")
+    g.enqueue("msg", timeout=0.1)
+    n.enqueue(b"data", timeout=0.2)
+    assert stub.called == [("msg", 0.1)]
+    assert conn.actions == [("pub", "demo", b"data"), ("flush", 0.2)]
+
+
+def test_async_grpc_and_nats_clients():
+    stub = DummyAsyncStub()
+    conn = DummyAsyncConn()
+    g = AsyncGrpcClient(stub)
+    n = AsyncNatsClient(conn, subject="demo")
+    asyncio.run(g.enqueue("msg", timeout=0.1))
+    asyncio.run(n.enqueue(b"data", timeout=0.2))
+    assert stub.called == [("msg", 0.1)]
+    assert conn.actions == [("pub", "demo", b"data"), ("flush", 0.2)]


### PR DESCRIPTION
## Summary
- test `research.gather` and `async_gather`
- test transport clients and `get_client`
- test `DagCronScheduler` dependency logic and helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd40bd55083269684dca6cb726145