### PR TITLE
Add CLI disable/run test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,4 +557,25 @@ def test_cli_run_async_user_id(monkeypatch):
     assert captured["run"].user_hash != "bob"
 
 
+def test_cli_disable_prevents_run(monkeypatch):
+    class Demo:
+        name = "demo"
+
+        def run(self):
+            return "ok"
+
+    sched = BaseScheduler()
+    sched.register_task("demo", Demo())
+    monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["disable", "demo"])
+    assert result.exit_code == 0
+    assert "demo disabled" in result.output
+
+    result = runner.invoke(app, ["run", "demo"])
+    assert result.exit_code != 0
+    assert "disabled" in (result.stderr or result.output)
+
+
 


### PR DESCRIPTION
## Summary
- ensure disabling a task via CLI prevents running it

## Testing
- `ruff check`
- `pytest -q tests/test_cli.py::test_cli_disable_prevents_run -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0ac0401c8326a1402012b31d284c