### PR TITLE
Add plugin path validation

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -140,6 +140,8 @@ except Exception:  # pragma: no cover - optional plugin may fail to import
 def load_plugin(path: str) -> BaseTask:
     """Load ``path`` of the form ``module:Class`` and return an instance."""
 
+    if path.count(":") != 1:
+        raise ValueError("path must be 'module:Class'")
     module_path, class_name = path.split(":")
     module = importlib.import_module(module_path)
     cls = getattr(module, class_name)

--- a/tests/test_plugin_load_api.py
+++ b/tests/test_plugin_load_api.py
@@ -1,0 +1,31 @@
+import tempfile
+from fastapi.testclient import TestClient
+from task_cascadence.api import app
+from task_cascadence.scheduler import CronScheduler
+from task_cascadence.plugins import CronTask
+
+
+class DummyTask(CronTask):
+    name = "dummy"
+
+    def run(self):
+        return "ok"
+
+def setup_scheduler(monkeypatch, tmp_path):
+    sched = CronScheduler(storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+    sched.register_task(name_or_task="dummy", task_or_expr=task)
+    monkeypatch.setattr("task_cascadence.api.get_default_scheduler", lambda: sched)
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda run, user_id=None: None)
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", tmp.name)
+    monkeypatch.setenv("CASCADENCE_TASKS_PATH", str(tmp_path / "tasks.yml"))
+    return sched
+
+
+def test_register_task_bad_format(monkeypatch, tmp_path):
+    setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post("/tasks", params={"path": "bad:format:extra"})
+    assert resp.status_code == 400
+    assert "module:Class" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- validate plugin paths contain exactly one colon
- test error handling when the API receives a bad plugin path

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1aec8cd883269546328d3b7df78b