### PR TITLE
Add configurable ideas path

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,10 @@ with the variables below. When set, they override values from the YAML file:
     Location of the ``pointers.yml`` file used by :class:`PointerStore`.
 ``CASCADENCE_TASKS_PATH``
     Location of the ``tasks.yml`` file used by :class:`TaskStore`.
+``CASCADENCE_IDEAS_PATH``
+    Location of the ``ideas.yml`` file used by :class:`IdeaStore`.
 
-The YAML configuration may also define ``stages_path``, ``pointers_path`` and ``tasks_path`` to override these defaults.
+The YAML configuration may also define ``stages_path``, ``pointers_path``, ``tasks_path`` and ``ideas_path`` to override these defaults.
 
 Example ``cascadence.yml`` enabling gRPC transport and research support:
 
@@ -444,6 +446,7 @@ hash_secret: supersecret
 stages_path: /tmp/stages.yml
 pointers_path: /tmp/pointers.yml
 tasks_path: /tmp/tasks.yml
+ideas_path: /tmp/ideas.yml
 broadcast_pointers: true
 ```
 

--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -78,6 +78,11 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     elif "pointers_path" in cfg:
         cfg["pointers_path"] = cfg["pointers_path"]
 
+    if "CASCADENCE_IDEAS_PATH" in os.environ:
+        cfg["ideas_path"] = os.environ["CASCADENCE_IDEAS_PATH"]
+    elif "ideas_path" in cfg:
+        cfg["ideas_path"] = cfg["ideas_path"]
+
     if "ume_broadcast_pointers" in cfg:
         cfg["ume_broadcast_pointers"] = bool(cfg["ume_broadcast_pointers"])
 

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -2,22 +2,59 @@ import yaml
 from task_cascadence.config import load_config
 from task_cascadence.stage_store import StageStore
 from task_cascadence.pointer_store import PointerStore
+from task_cascadence.idea_store import IdeaStore
 
 
 def test_config_paths(monkeypatch, tmp_path):
     cfg = tmp_path / "cfg.yml"
     stages = tmp_path / "stages.yml"
     pointers = tmp_path / "pointers.yml"
-    cfg.write_text(yaml.safe_dump({"stages_path": str(stages), "pointers_path": str(pointers)}))
+    ideas = tmp_path / "ideas.yml"
+    cfg.write_text(
+        yaml.safe_dump({
+            "stages_path": str(stages),
+            "pointers_path": str(pointers),
+            "ideas_path": str(ideas),
+        })
+    )
     monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg))
     monkeypatch.delenv("CASCADENCE_POINTERS_PATH", raising=False)
     monkeypatch.delenv("CASCADENCE_STAGES_PATH", raising=False)
+    monkeypatch.delenv("CASCADENCE_IDEAS_PATH", raising=False)
 
     cfg_data = load_config()
     assert cfg_data["stages_path"] == str(stages)
     assert cfg_data["pointers_path"] == str(pointers)
+    assert cfg_data["ideas_path"] == str(ideas)
 
     s_store = StageStore()
     p_store = PointerStore()
+    i_store = IdeaStore()
     assert s_store.path == stages
     assert p_store.path == pointers
+    assert i_store.path == ideas
+
+
+def test_env_config_paths(monkeypatch, tmp_path):
+    stages = tmp_path / "stages.yml"
+    pointers = tmp_path / "pointers.yml"
+    ideas = tmp_path / "ideas.yml"
+
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(stages))
+    monkeypatch.setenv("CASCADENCE_POINTERS_PATH", str(pointers))
+    monkeypatch.setenv("CASCADENCE_IDEAS_PATH", str(ideas))
+    monkeypatch.delenv("CASCADENCE_CONFIG", raising=False)
+
+    cfg_data = load_config()
+
+    assert cfg_data["stages_path"] == str(stages)
+    assert cfg_data["pointers_path"] == str(pointers)
+    assert cfg_data["ideas_path"] == str(ideas)
+
+    s_store = StageStore()
+    p_store = PointerStore()
+    i_store = IdeaStore()
+
+    assert s_store.path == stages
+    assert p_store.path == pointers
+    assert i_store.path == ideas


### PR DESCRIPTION
## Summary
- expose ideas path option in `load_config`
- test and document `CASCADENCE_IDEAS_PATH`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2df0fad08326b693976d8d6223a3