### PR TITLE
Add unschedule stage event

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -358,6 +358,9 @@ class CronScheduler(BaseScheduler):
             pass
         self.schedules.pop(name, None)
         self._save_schedules()
+        from ..ume import emit_stage_update
+
+        emit_stage_update(name, "unschedule")
 
     def pause_task(self, name: str) -> None:
         """Pause ``name`` and emit a stage event."""


### PR DESCRIPTION
## Summary
- emit an `unschedule` stage update when removing a job
- test that unscheduling records the stage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d30bb0eec8326846e2113251c46fb