### PR TITLE
feat: persist webhook task instances

### DIFF
--- a/task_cascadence/webhook.py
+++ b/task_cascadence/webhook.py
@@ -1,9 +1,23 @@
 from fastapi import FastAPI, Request
 import uvicorn
 
-from .plugins import webhook_task_registry
+from .plugins import WebhookTask, webhook_task_registry
 
 app = FastAPI()
+
+
+# Store a singleton instance of each registered webhook task.
+webhook_task_instances: dict[type[WebhookTask], WebhookTask] = {}
+
+
+def _get_task_instance(task_cls: type[WebhookTask]) -> WebhookTask:
+    """Return the singleton instance for ``task_cls``."""
+
+    task = webhook_task_instances.get(task_cls)
+    if task is None:
+        task = task_cls()
+        webhook_task_instances[task_cls] = task
+    return task
 
 
 @app.post("/webhook/github")
@@ -11,7 +25,7 @@ async def github_webhook(request: Request):
     payload = await request.json()
     event_type = request.headers.get("X-GitHub-Event", "")
     for task_cls in webhook_task_registry:
-        task = task_cls()
+        task = _get_task_instance(task_cls)
         if hasattr(task, "handle_event"):
             task.handle_event("github", event_type, payload)
     return {"status": "received"}
@@ -22,7 +36,7 @@ async def calcom_webhook(request: Request):
     payload = await request.json()
     event_type = request.headers.get("Cal-Event-Type", "")
     for task_cls in webhook_task_registry:
-        task = task_cls()
+        task = _get_task_instance(task_cls)
         if hasattr(task, "handle_event"):
             task.handle_event("calcom", event_type, payload)
     return {"status": "received"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,7 +5,7 @@ from task_cascadence.plugins import (
     register_webhook_task,
     webhook_task_registry,
 )
-from task_cascadence.webhook import app
+from task_cascadence.webhook import app, webhook_task_instances
 
 
 class DummyWebhookTask(WebhookTask):
@@ -27,41 +27,55 @@ def test_webhook_routing():
 
 def test_registered_task_receives_event():
     webhook_task_registry.clear()
+    webhook_task_instances.clear()
 
     @register_webhook_task
     class CollectorTask(WebhookTask):
-        events = []
+        def __init__(self):
+            self.events: list[tuple[str, str, dict]] = []
 
         def handle_event(self, source, event_type, payload):
-            self.__class__.events.append((source, event_type, payload))
+            self.events.append((source, event_type, payload))
 
     client = TestClient(app)
     payload = {"action": "opened"}
     headers = {"X-GitHub-Event": "issues"}
 
     response = client.post("/webhook/github", json=payload, headers=headers)
+    response = client.post("/webhook/github", json=payload, headers=headers)
 
     assert response.json() == {"status": "received"}
-    assert CollectorTask.events == [("github", "issues", payload)]
+    task = webhook_task_instances[CollectorTask]
+    assert task.events == [
+        ("github", "issues", payload),
+        ("github", "issues", payload),
+    ]
 
 
 def test_calcom_task_receives_event():
     """Webhook tasks should receive Cal.com events."""
 
     webhook_task_registry.clear()
+    webhook_task_instances.clear()
 
     @register_webhook_task
     class CollectorTask(WebhookTask):
-        events = []
+        def __init__(self):
+            self.events: list[tuple[str, str, dict]] = []
 
         def handle_event(self, source, event_type, payload):
-            self.__class__.events.append((source, event_type, payload))
+            self.events.append((source, event_type, payload))
 
     client = TestClient(app)
     payload = {"event": "created"}
     headers = {"Cal-Event-Type": "booking"}
 
     response = client.post("/webhook/calcom", json=payload, headers=headers)
+    response = client.post("/webhook/calcom", json=payload, headers=headers)
 
     assert response.json() == {"status": "received"}
-    assert CollectorTask.events == [("calcom", "booking", payload)]
+    task = webhook_task_instances[CollectorTask]
+    assert task.events == [
+        ("calcom", "booking", payload),
+        ("calcom", "booking", payload),
+    ]


### PR DESCRIPTION
## Summary
- reuse webhook task instances instead of creating new ones each request
- test that webhook task state persists across multiple requests

## Testing
- `ruff check task_cascadence/webhook.py tests/test_webhook.py`
- `pytest tests/test_webhook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4c4a4838832696fa74499d64a416