### PR TITLE
Add suggestion engine and suggestions API

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -9,6 +9,7 @@ from ..cli import _pointer_add, _pointer_list, _pointer_receive
 from ..pipeline_registry import get_pipeline
 from ..plugins import load_plugin
 from ..task_store import TaskStore
+from ..suggestions.engine import get_default_engine
 
 app = FastAPI()
 
@@ -180,6 +181,43 @@ def pointer_receive(name: str, run_id: str, user_hash: str):
     return {"status": "stored"}
 
 
+@app.get("/suggestions")
+def suggestion_list():
+    """Return all generated suggestions."""
+
+    engine = get_default_engine()
+    return [s.__dict__ for s in engine.list()]
+
+
+@app.post("/suggestions/{suggestion_id}/accept")
+def suggestion_accept(
+    suggestion_id: str, user_id: str | None = Depends(get_user_id)
+):
+    """Accept a suggestion and enqueue its task."""
+
+    engine = get_default_engine()
+    engine.accept(suggestion_id, user_id=user_id)
+    return {"status": "accepted"}
+
+
+@app.post("/suggestions/{suggestion_id}/snooze")
+def suggestion_snooze(suggestion_id: str):
+    """Snooze a suggestion."""
+
+    engine = get_default_engine()
+    engine.snooze(suggestion_id)
+    return {"status": "snoozed"}
+
+
+@app.post("/suggestions/{suggestion_id}/dismiss")
+def suggestion_dismiss(suggestion_id: str):
+    """Dismiss a suggestion."""
+
+    engine = get_default_engine()
+    engine.dismiss(suggestion_id)
+    return {"status": "dismissed"}
+
+
 __all__ = [
     "app",
     "list_tasks",
@@ -194,4 +232,8 @@ __all__ = [
     "pointer_add",
     "pointer_list",
     "pointer_receive",
+    "suggestion_list",
+    "suggestion_accept",
+    "suggestion_snooze",
+    "suggestion_dismiss",
 ]

--- a/task_cascadence/suggestions/__init__.py
+++ b/task_cascadence/suggestions/__init__.py
@@ -1,0 +1,3 @@
+from .engine import Suggestion, SuggestionEngine, get_default_engine
+
+__all__ = ["Suggestion", "SuggestionEngine", "get_default_engine"]

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,77 @@
+import asyncio
+
+from task_cascadence.suggestions.engine import SuggestionEngine
+
+
+async def _prepare_engine(monkeypatch):
+    engine = SuggestionEngine()
+
+    async def fake_query():
+        return [
+            {
+                "title": "Example",
+                "description": "test description",
+                "task_name": "dummy",
+                "related": ["foo"],
+            }
+        ]
+
+    monkeypatch.setattr(engine, "_query_ume", fake_query)
+    monkeypatch.setattr(
+        "task_cascadence.suggestions.engine.gather",
+        lambda q: {"confidence": 0.9},
+    )
+    await engine.generate()
+    return engine
+
+
+def test_generation(monkeypatch):
+    engine = asyncio.run(_prepare_engine(monkeypatch))
+    suggestions = engine.list()
+    assert suggestions
+    s = suggestions[0]
+    assert s.title == "Example"
+    assert s.confidence == 0.9
+    assert s.related_entities == ["foo"]
+
+
+def test_snooze_and_dismiss(monkeypatch):
+    engine = asyncio.run(_prepare_engine(monkeypatch))
+    sid = engine.list()[0].id
+    engine.snooze(sid)
+    assert engine.get(sid).state == "snoozed"
+    engine.dismiss(sid)
+    assert engine.get(sid).state == "dismissed"
+
+
+def test_accept_enqueues_task(monkeypatch):
+    engine = asyncio.run(_prepare_engine(monkeypatch))
+    sid = engine.list()[0].id
+
+    class DummyScheduler:
+        def __init__(self):
+            self.ran = []
+
+        def run_task(self, name):
+            self.ran.append(name)
+
+    scheduler = DummyScheduler()
+    monkeypatch.setattr(
+        "task_cascadence.suggestions.engine.get_default_scheduler", lambda: scheduler
+    )
+
+    emitted = {}
+
+    def fake_emit(note, user_id=None):
+        emitted["text"] = note.note
+        emitted["user_id"] = user_id
+
+    monkeypatch.setattr(
+        "task_cascadence.suggestions.engine.emit_task_note", fake_emit
+    )
+
+    engine.accept(sid, user_id="alice")
+    assert scheduler.ran == ["dummy"]
+    assert emitted["user_id"] == "alice"
+    assert "accepted" in emitted["text"]
+    assert engine.get(sid).state == "accepted"


### PR DESCRIPTION
## Summary
- implement SuggestionEngine with periodic UME queries and acceptance handling
- expose /suggestions API routes for listing and user actions
- cover suggestion generation and actions with unit tests

## Testing
- `ruff check task_cascadence/suggestions/engine.py task_cascadence/api/__init__.py tests/test_suggestions.py`
- `pytest tests/test_suggestions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e5462756083269ec5736c1a5eef89