### PR TITLE
feat: add suggestion configuration

### DIFF
--- a/task_cascadence/config.py
+++ b/task_cascadence/config.py
@@ -86,5 +86,22 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     if "ume_broadcast_pointers" in cfg:
         cfg["ume_broadcast_pointers"] = bool(cfg["ume_broadcast_pointers"])
 
+    suggestions_cfg = cfg.get("suggestions") or {}
+    enabled_env = os.getenv("CASCADENCE_SUGGESTIONS_ENABLED")
+    if enabled_env is not None:
+        suggestions_cfg["enabled"] = enabled_env.lower() not in ("0", "false", "no")
+    else:
+        suggestions_cfg["enabled"] = bool(suggestions_cfg.get("enabled", True))
+
+    categories_env = os.getenv("CASCADENCE_SUGGESTIONS_CATEGORIES")
+    if categories_env is not None:
+        suggestions_cfg["categories"] = [
+            c.strip() for c in categories_env.split(",") if c.strip()
+        ]
+    else:
+        suggestions_cfg["categories"] = list(suggestions_cfg.get("categories", []))
+
+    cfg["suggestions"] = suggestions_cfg
+
     return cfg
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -154,3 +154,38 @@ def test_initialize_unknown_scheduler(monkeypatch):
         importlib.reload(task_cascadence)
         task_cascadence.initialize()
 
+
+def test_suggestions_defaults(monkeypatch):
+    monkeypatch.delenv("CASCADENCE_SUGGESTIONS_ENABLED", raising=False)
+    monkeypatch.delenv("CASCADENCE_SUGGESTIONS_CATEGORIES", raising=False)
+    monkeypatch.delenv("CASCADENCE_CONFIG", raising=False)
+    cfg = load_config()
+    assert cfg["suggestions"]["enabled"] is True
+    assert cfg["suggestions"]["categories"] == []
+
+
+def test_suggestions_yaml(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(
+        "suggestions:\n  enabled: false\n  categories:\n    - personal\n    - finance\n"
+    )
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg_file))
+    monkeypatch.delenv("CASCADENCE_SUGGESTIONS_ENABLED", raising=False)
+    monkeypatch.delenv("CASCADENCE_SUGGESTIONS_CATEGORIES", raising=False)
+    cfg = load_config()
+    assert cfg["suggestions"]["enabled"] is False
+    assert cfg["suggestions"]["categories"] == ["personal", "finance"]
+
+
+def test_suggestions_env_overrides(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(
+        "suggestions:\n  enabled: true\n  categories:\n    - personal\n"
+    )
+    monkeypatch.setenv("CASCADENCE_CONFIG", str(cfg_file))
+    monkeypatch.setenv("CASCADENCE_SUGGESTIONS_ENABLED", "0")
+    monkeypatch.setenv("CASCADENCE_SUGGESTIONS_CATEGORIES", "finance,work")
+    cfg = load_config()
+    assert cfg["suggestions"]["enabled"] is False
+    assert cfg["suggestions"]["categories"] == ["finance", "work"]
+


### PR DESCRIPTION
## Summary
- allow configuring suggestions.enabled and suggestions.categories via YAML or env vars
- skip suggestion generation for disabled categories or when suggestions disabled
- cover suggestions config defaults and overrides with tests

## Testing
- `python -m ruff check task_cascadence/config.py task_cascadence/suggestions/engine.py tests/test_config_loader.py`
- `pytest tests/test_config_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688e56335348832692ba82975784113c