### PR TITLE
feat: add intent input and CLI

### DIFF
--- a/constellation-dashboard/src/components/IntentInput.test.tsx
+++ b/constellation-dashboard/src/components/IntentInput.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import IntentInput from './IntentInput';
+
+afterEach(() => {
+  // @ts-ignore
+  global.fetch = undefined;
+});
+
+test('handles clarification flow', async () => {
+  const fetchMock = jest
+    .fn()
+    .mockResolvedValueOnce({ json: async () => ({ clarification: 'Which account?' }) })
+    .mockResolvedValueOnce({ json: async () => ({ tasks: ['Task A'] }) });
+  // @ts-ignore
+  global.fetch = fetchMock;
+
+  const { getByTestId, getByText } = render(<IntentInput />);
+
+  fireEvent.change(getByTestId('intent-input'), { target: { value: 'pay bills' } });
+  fireEvent.click(getByText('Submit'));
+
+  await waitFor(() => getByTestId('clar-input'));
+  fireEvent.change(getByTestId('clar-input'), { target: { value: 'Personal' } });
+  fireEvent.click(getByText('Submit'));
+
+  await waitFor(() => getByTestId('task-preview'));
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    1,
+    '/intent',
+    expect.objectContaining({ body: JSON.stringify({ text: 'pay bills' }) })
+  );
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    2,
+    '/intent',
+    expect.objectContaining({ body: JSON.stringify({ text: 'pay bills', clarification: 'Personal' }) })
+  );
+  expect(getByTestId('task-preview').textContent).toContain('Task A');
+});
+
+test('shows tasks on success', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({ json: async () => ({ tasks: ['Task B'] }) });
+  // @ts-ignore
+  global.fetch = fetchMock;
+
+  const { getByTestId, getByText } = render(<IntentInput />);
+
+  fireEvent.change(getByTestId('intent-input'), { target: { value: 'buy milk' } });
+  fireEvent.click(getByText('Submit'));
+
+  await waitFor(() => getByTestId('task-preview'));
+  expect(getByTestId('task-preview').textContent).toContain('Task B');
+});

--- a/constellation-dashboard/src/components/IntentInput.tsx
+++ b/constellation-dashboard/src/components/IntentInput.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+const IntentInput: React.FC = () => {
+  const [text, setText] = useState('');
+  const [clarPrompt, setClarPrompt] = useState<string | null>(null);
+  const [clarAnswer, setClarAnswer] = useState('');
+  const [tasks, setTasks] = useState<string[]>([]);
+
+  const submit = async () => {
+    const payload: Record<string, unknown> = { text };
+    if (clarPrompt) {
+      payload.clarification = clarAnswer;
+    }
+    const res = await fetch('/intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (data.clarification) {
+      setClarPrompt(data.clarification);
+      setClarAnswer('');
+      setTasks([]);
+    } else if (data.tasks) {
+      setTasks(data.tasks);
+      setClarPrompt(null);
+    }
+  };
+
+  return (
+    <div>
+      {!clarPrompt && (
+        <input
+          data-testid="intent-input"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+      )}
+      {clarPrompt && (
+        <div>
+          <div>{clarPrompt}</div>
+          <input
+            data-testid="clar-input"
+            value={clarAnswer}
+            onChange={(e) => setClarAnswer(e.target.value)}
+          />
+        </div>
+      )}
+      <button onClick={submit}>Submit</button>
+      {tasks.length > 0 && (
+        <ul data-testid="task-preview">
+          {tasks.map((t, i) => (
+            <li key={i}>{t}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default IntentInput;

--- a/d0tTino_cli.py
+++ b/d0tTino_cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import requests
+import typer
+
+app = typer.Typer(help="Interact with TaskCascadence intent API")
+
+
+def _post(base_url: str, payload: dict) -> dict:
+    url = f"{base_url.rstrip('/')}/intent"
+    response = requests.post(url, json=payload, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+@app.command()
+def intent(text: str, base_url: str = "http://localhost:8000") -> None:
+    """Submit ``TEXT`` and interactively resolve intent."""
+
+    payload: dict = {"text": text}
+
+    while True:
+        data = _post(base_url, payload)
+        clarification = data.get("clarification")
+        if clarification:
+            typer.echo(clarification)
+            answer = input("")
+            payload["clarification"] = answer
+            continue
+        tasks = data.get("tasks", [])
+        if tasks:
+            typer.echo("Derived tasks:")
+            for task in tasks:
+                typer.echo(f"- {task}")
+        break
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_intent_cli.py
+++ b/tests/test_intent_cli.py
@@ -1,0 +1,61 @@
+import builtins
+from typer.testing import CliRunner
+
+import requests
+
+from d0tTino_cli import app
+
+
+class Resp:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - nothing to raise
+        pass
+
+
+def test_clarification_flow(monkeypatch):
+    calls: list[dict] = []
+    responses = [
+        Resp({"clarification": "Which account?"}),
+        Resp({"tasks": ["Task A"]}),
+    ]
+
+    def fake_post(url, json=None, timeout=0):
+        calls.append(dict(json))
+        return responses[len(calls) - 1]
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "Personal")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["pay bills"])
+
+    assert result.exit_code == 0
+    assert "Which account?" in result.stdout
+    assert "Derived tasks:" in result.stdout
+    assert "Task A" in result.stdout
+    assert calls == [
+        {"text": "pay bills"},
+        {"text": "pay bills", "clarification": "Personal"},
+    ]
+
+
+def test_success_flow(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_post(url, json=None, timeout=0):
+        calls.append(json)
+        return Resp({"tasks": ["Task B"]})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["buy milk"])
+
+    assert result.exit_code == 0
+    assert "Task B" in result.stdout
+    assert calls == [{"text": "buy milk"}]


### PR DESCRIPTION
## Summary
- add interactive d0tTino CLI that talks to /intent, asks clarifications, and previews tasks
- introduce React IntentInput component for free-form submissions with clarifications and task previews
- cover both interfaces with integration tests for clarification and success flows

## Testing
- `ruff check d0tTino_cli.py task_cascadence tests`
- `pytest` *(fails: mypy missing type stubs, async plugin, timezone data, webhook task registration)*
- `pytest tests/test_intent_cli.py::test_clarification_flow tests/test_intent_cli.py::test_success_flow -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e8af89aa88326bad2d3086420dd8b