### PR TITLE
Add intent analysis endpoint with UME context

### DIFF
--- a/task_cascadence/intent.py
+++ b/task_cascadence/intent.py
@@ -1,0 +1,58 @@
+"""Intent resolution using an LLM with optional UME context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .research import gather
+
+
+@dataclass
+class IntentResult:
+    """Represents the inferred task intent."""
+
+    task: Optional[str]
+    arguments: Dict[str, Any]
+    confidence: float
+    requires_clarification: bool = False
+
+
+CLARIFICATION_THRESHOLD = 0.7
+
+
+def _build_prompt(message: str, context: List[str]) -> str:
+    """Combine *message* and *context* into a single prompt for the LLM."""
+
+    parts = [
+        "You are an intent classification service."
+        " Use the provided context to resolve references in the user message.",
+    ]
+    if context:
+        parts.append("Context:\n" + "\n".join(context))
+    parts.append(f"User: {message}")
+    parts.append(
+        "Respond with JSON containing keys 'task', 'arguments' and 'confidence'"
+    )
+    return "\n\n".join(parts)
+
+
+def resolve_intent(
+    message: str, context: Optional[List[str]] = None, *, threshold: float = CLARIFICATION_THRESHOLD
+) -> IntentResult:
+    """Return the :class:`IntentResult` for *message* using *context* for disambiguation."""
+
+    ctx = context or []
+    prompt = _build_prompt(message, ctx)
+    result = gather(prompt)
+    task: Optional[str] = None
+    args: Dict[str, Any] = {}
+    confidence = 0.0
+    if isinstance(result, dict):
+        task = result.get("task")
+        args = result.get("arguments") or result.get("args") or {}
+        confidence = float(result.get("confidence", 0.0))
+    intent = IntentResult(task=task, arguments=args, confidence=confidence)
+    if confidence < threshold:
+        intent.requires_clarification = True
+    return intent

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -45,16 +45,20 @@ class WebhookTask(BaseTask):
 
 _old_module = sys.modules.get(__name__)
 webhook_task_registry: list[type[WebhookTask]]
+webhook_task_instances: dict[type[WebhookTask], WebhookTask]
 if _old_module and hasattr(_old_module, "webhook_task_registry"):
     webhook_task_registry = _old_module.webhook_task_registry  # type: ignore[assignment]
+    webhook_task_instances = _old_module.webhook_task_instances  # type: ignore[assignment]
 else:
     webhook_task_registry = []
+    webhook_task_instances = {}
 
 
 def register_webhook_task(cls: type[WebhookTask]) -> type[WebhookTask]:
     """Register a ``WebhookTask`` subclass for event delivery."""
 
     webhook_task_registry.append(cls)
+    webhook_task_instances.setdefault(cls, cls())
     return cls
 
 

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+
+from task_cascadence.api import app
+
+
+def test_disambiguation_with_context(monkeypatch):
+    captured = {}
+
+    def fake_gather(prompt: str):
+        captured['prompt'] = prompt
+        return {
+            'task': 'send_email',
+            'arguments': {'recipient': 'bob@example.com'},
+            'confidence': 0.9,
+        }
+
+    monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
+    client = TestClient(app)
+    resp = client.post(
+        '/intent',
+        json={'message': 'Schedule it for tomorrow', 'context': ['send email to bob@example.com']},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['task'] == 'send_email'
+    assert data['confidence'] == 0.9
+    assert not data['clarification']
+    assert 'send email to bob@example.com' in captured['prompt']
+
+
+def test_clarification_triggered(monkeypatch):
+    def fake_gather(prompt: str):
+        return {'task': None, 'arguments': {}, 'confidence': 0.2}
+
+    monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
+    client = TestClient(app)
+    resp = client.post('/intent', json={'message': 'do something', 'context': []})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['clarification']
+    assert data['confidence'] == 0.2


### PR DESCRIPTION
## Summary
- add intent resolution module that prompts LLM with UME context
- expose `/intent` API for structured intent analysis
- share webhook task instances via plugin registry to stabilise tests

## Testing
- `ruff check task_cascadence/intent.py task_cascadence/api/__init__.py task_cascadence/plugins/__init__.py task_cascadence/webhook.py tests/test_intent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e88ddd8f083269acfacff6e88896d