### PR TITLE
Add suggestion pattern detection and decision tracking

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -220,20 +220,24 @@ def suggestion_accept(
 
 
 @app.post("/suggestions/{suggestion_id}/snooze")
-def suggestion_snooze(suggestion_id: str):
+def suggestion_snooze(
+    suggestion_id: str, user_id: str | None = Depends(get_user_id)
+):
     """Snooze a suggestion."""
 
     engine = get_default_engine()
-    engine.snooze(suggestion_id)
+    engine.snooze(suggestion_id, user_id=user_id)
     return {"status": "snoozed"}
 
 
 @app.post("/suggestions/{suggestion_id}/dismiss")
-def suggestion_dismiss(suggestion_id: str):
+def suggestion_dismiss(
+    suggestion_id: str, user_id: str | None = Depends(get_user_id)
+):
     """Dismiss a suggestion."""
 
     engine = get_default_engine()
-    engine.dismiss(suggestion_id)
+    engine.dismiss(suggestion_id, user_id=user_id)
     return {"status": "dismissed"}
 
 

--- a/task_cascadence/suggestion_store.py
+++ b/task_cascadence/suggestion_store.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Any, Dict, List
+from datetime import datetime, timezone
+
+import yaml
+
+from .config import load_config
+
+
+class SuggestionStore:
+    """Persistent store for suggestion decisions."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = os.getenv("CASCADENCE_SUGGESTIONS_PATH")
+        if path is None:
+            cfg = load_config()
+            path = cfg.get("suggestions_path")
+        if path is None:
+            path = Path.home() / ".cascadence" / "suggestions.yml"
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._data: List[Dict[str, Any]] = self._load()
+
+    def _load(self) -> List[Dict[str, Any]]:
+        if self.path.exists():
+            with open(self.path, "r") as fh:
+                data = yaml.safe_load(fh) or []
+                if isinstance(data, list):
+                    return data
+        return []
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            yaml.safe_dump(self._data, fh)
+
+    def add_decision(self, pattern: str, decision: str, user_hash: str | None) -> None:
+        entry: Dict[str, Any] = {
+            "pattern": pattern,
+            "decision": decision,
+            "time": datetime.now(timezone.utc).isoformat(),
+        }
+        if user_hash is not None:
+            entry["user_hash"] = user_hash
+        self._data.append(entry)
+        self._save()
+
+    def get_decisions(self) -> List[Dict[str, Any]]:
+        return list(self._data)
+
+
+__all__ = ["SuggestionStore"]
+

--- a/tests/test_ume_patterns.py
+++ b/tests/test_ume_patterns.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+import task_cascadence.ume as ume
+from task_cascadence.ume.models import IdeaSeed
+
+
+def test_detect_repeated_bookmarks(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_IDEAS_PATH", str(tmp_path / "ideas.yml"))
+    monkeypatch.setenv("CASCADENCE_SUGGESTIONS_PATH", str(tmp_path / "decisions.yml"))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    ume._idea_store = None
+    ume._suggestion_store = None
+
+    store = ume._get_idea_store()
+    seed = IdeaSeed(text="foo", user_hash=ume._hash_user_id("alice"))
+    store.add_seed(seed)
+    store.add_seed(seed)
+
+    patterns = ume.detect_event_patterns(user_id="alice")
+    assert patterns
+    assert patterns[0]["context"]["count"] == 2
+
+
+def test_dismissed_suggestions_suppressed(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_IDEAS_PATH", str(tmp_path / "ideas.yml"))
+    monkeypatch.setenv("CASCADENCE_SUGGESTIONS_PATH", str(tmp_path / "decisions.yml"))
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    ume._idea_store = None
+    ume._suggestion_store = None
+
+    store = ume._get_idea_store()
+    seed = IdeaSeed(text="bar", user_hash=ume._hash_user_id("alice"))
+    store.add_seed(seed)
+    store.add_seed(seed)
+    ume.record_suggestion_decision(
+        "Repeated bookmark: bar", "dismissed", user_id="alice"
+    )
+
+    patterns = ume.detect_event_patterns(user_id="alice")
+    assert patterns == []
+
+    decision_store = ume._get_suggestion_store()
+    decision_store._data[0]["time"] = (
+        datetime.now(timezone.utc) - timedelta(days=31)
+    ).isoformat()
+    decision_store._save()
+    patterns = ume.detect_event_patterns(user_id="alice")
+    assert patterns
+


### PR DESCRIPTION
## Summary
- Track suggestion decisions with a persistent store and expose helpers to record them
- Detect repeated bookmark patterns while suppressing those dismissed within 30 days
- Accept user IDs on snooze/dismiss endpoints and enrich suggestions with context

## Testing
- `ruff check task_cascadence tests`
- `pytest tests/test_suggestions.py tests/test_ume_patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_688eacc118608326a9f09a1dfe41c821