### PR TITLE
Add calendar event creation workflow

### DIFF
--- a/task_cascadence/workflows/__init__.py
+++ b/task_cascadence/workflows/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+_registry: Dict[str, Callable[..., Any]] = {}
+
+
+def subscribe(event: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a workflow for *event*."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        _registry[event] = func
+        return func
+
+    return decorator
+
+
+def dispatch(event: str, *args: Any, **kwargs: Any) -> Any:
+    """Dispatch *event* to the registered workflow."""
+
+    handler = _registry.get(event)
+    if not handler:
+        raise ValueError(f"No workflow registered for {event}")
+    return handler(*args, **kwargs)
+
+
+# Import built-in workflows so they register themselves
+from . import calendar_event_creation  # noqa: F401,E402

--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from . import subscribe
+from ..http_utils import request_with_retry
+from .. import research
+from ..ume import emit_stage_update_event
+
+
+def _has_permission(user_id: str, *, ume_base: str = "http://ume") -> bool:
+    """Return ``True`` if ``user_id`` may create calendar events."""
+
+    url = f"{ume_base.rstrip('/')}/v1/permissions/calendar:create"
+    resp = request_with_retry("GET", url, params={"user_id": user_id}, timeout=5)
+    data = resp.json()
+    return bool(data.get("allowed"))
+
+
+@subscribe("calendar.event.create")
+def create_calendar_event(
+    payload: Dict[str, Any], *, user_id: str, base_url: str = "http://localhost"
+) -> Dict[str, Any]:
+    """Persist a calendar event after validation and permission checks."""
+
+    for field in ("title", "start", "end"):
+        if field not in payload:
+            raise ValueError(f"missing required field: {field}")
+    if not _has_permission(user_id):
+        raise PermissionError("user lacks calendar:create permission")
+
+    event_data = dict(payload)
+    if payload.get("location"):
+        try:
+            event_data["travel_time"] = research.gather(
+                f"travel time to {payload['location']}"
+            )
+        except RuntimeError:
+            pass
+
+    url = f"{base_url.rstrip('/')}/v1/calendar/events"
+    resp = request_with_retry("POST", url, json=event_data, timeout=5)
+    emit_stage_update_event("calendar.event.created", "created", user_id=user_id)
+    return resp.json()

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -1,0 +1,52 @@
+from task_cascadence.workflows import dispatch
+from task_cascadence.workflows import calendar_event_creation as cec
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_calendar_event_creation(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, timeout, **kwargs):
+        calls.append((method, url, kwargs))
+        if method == "GET":
+            return DummyResponse({"allowed": True})
+        assert method == "POST"
+        return DummyResponse({"id": "evt1"})
+
+    emitted = {}
+
+    def fake_emit(name, stage, user_id=None, **_kwargs):
+        emitted["event"] = (name, stage, user_id)
+
+    def fake_research(query):
+        emitted["research"] = query
+        return {"duration": "15m"}
+
+    monkeypatch.setattr(cec, "request_with_retry", fake_request)
+    monkeypatch.setattr(cec, "emit_stage_update_event", fake_emit)
+    monkeypatch.setattr(cec.research, "gather", fake_research)
+
+    payload = {
+        "title": "Lunch",
+        "start": "2024-01-01T12:00:00Z",
+        "end": "2024-01-01T13:00:00Z",
+        "location": "Cafe",
+    }
+
+    result = dispatch("calendar.event.create", payload, user_id="alice", base_url="http://svc")
+
+    assert result == {"id": "evt1"}
+    assert calls[0][0] == "GET"
+    assert "permissions" in calls[0][1]
+    assert calls[1][0] == "POST"
+    assert calls[1][1] == "http://svc/v1/calendar/events"
+    assert calls[1][2]["json"]["travel_time"] == {"duration": "15m"}
+    assert emitted["event"] == ("calendar.event.created", "created", "alice")
+    assert emitted["research"] == "travel time to Cafe"


### PR DESCRIPTION
## Summary
- add workflow dispatcher with subscribe/dispatch helper
- implement calendar event creation workflow with validation, permission checks, travel-time research, persistence and event emission
- test event creation workflow registration and behavior

## Testing
- `ruff check task_cascadence/workflows tests/test_calendar_workflow.py`
- `pytest tests/test_calendar_workflow.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_688ebb52e3748326ad42c596d0454198