### PR TITLE
feat: add group context to task execution

### DIFF
--- a/task_cascadence/scheduler/cronyx.py
+++ b/task_cascadence/scheduler/cronyx.py
@@ -52,23 +52,35 @@ class CronyxScheduler(BaseScheduler):
         *,
         use_temporal: bool | None = None,
         user_id: str | None = None,
+        group_id: str | None = None,
     ) -> Any:
         if (
             name in self._tasks
             and not self._tasks[name]["disabled"]
             and not self._tasks[name].get("paused")
         ):
-            return super().run_task(name, use_temporal=use_temporal, user_id=user_id)
+            return super().run_task(
+                name, use_temporal=use_temporal, user_id=user_id, group_id=group_id
+            )
         payload = {"task": name}
         if user_id is not None:
             payload["user_id"] = _hash_user_id(user_id)
+        if group_id is not None:
+            payload["group_id"] = group_id
         data = self._request("POST", "/jobs", json=payload)
         return data.get("result")
 
     def schedule_task(
-        self, name: str, cron_expression: str, *, user_id: str | None = None
+        self,
+        name: str,
+        cron_expression: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
     ) -> Any:
         payload = {"task": name, "cron": cron_expression}
         if user_id is not None:
             payload["user_id"] = _hash_user_id(user_id)
+        if group_id is not None:
+            payload["group_id"] = group_id
         return self._request("POST", "/jobs", json=payload)

--- a/task_cascadence/suggestions/engine.py
+++ b/task_cascadence/suggestions/engine.py
@@ -104,24 +104,47 @@ class SuggestionEngine:
     def get(self, suggestion_id: str) -> Suggestion:
         return self._suggestions[suggestion_id]
 
-    def accept(self, suggestion_id: str, user_id: str | None = None) -> None:
+    def accept(
+        self,
+        suggestion_id: str,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         suggestion = self.get(suggestion_id)
         suggestion.state = "accepted"
         if suggestion.task_name:
             scheduler = get_default_scheduler()
-            scheduler.run_task(suggestion.task_name)
-        emit_acceptance_event(suggestion.title, user_id=user_id)
-        record_suggestion_decision(suggestion.title, "accepted", user_id=user_id)
+            scheduler.run_task(
+                suggestion.task_name, user_id=user_id, group_id=group_id
+            )
+        emit_acceptance_event(suggestion.title, user_id=user_id, group_id=group_id)
+        record_suggestion_decision(
+            suggestion.title, "accepted", user_id=user_id, group_id=group_id
+        )
 
-    def snooze(self, suggestion_id: str, user_id: str | None = None) -> None:
+    def snooze(
+        self,
+        suggestion_id: str,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         suggestion = self.get(suggestion_id)
         suggestion.state = "snoozed"
-        record_suggestion_decision(suggestion.title, "snoozed", user_id=user_id)
+        record_suggestion_decision(
+            suggestion.title, "snoozed", user_id=user_id, group_id=group_id
+        )
 
-    def dismiss(self, suggestion_id: str, user_id: str | None = None) -> None:
+    def dismiss(
+        self,
+        suggestion_id: str,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         suggestion = self.get(suggestion_id)
         suggestion.state = "dismissed"
-        record_suggestion_decision(suggestion.title, "dismissed", user_id=user_id)
+        record_suggestion_decision(
+            suggestion.title, "dismissed", user_id=user_id, group_id=group_id
+        )
 
 
 _default_engine: SuggestionEngine | None = None

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -298,6 +298,8 @@ def emit_idea_seed(
     if user_id is not None:
         seed.user_id = user_id
         seed.user_hash = _hash_user_id(user_id)
+    if group_id is not None:
+        seed.group_id = group_id
     _get_idea_store().add_seed(seed, group_id=group_id)
 
     if use_asyncio:


### PR DESCRIPTION
## Summary
- add `X-Group-ID` header to API and propagate group ids to scheduler and suggestions
- update TaskPipeline and schedulers to accept optional group IDs for UME emission
- test group-aware execution paths in API and orchestrator

## Testing
- `ruff check .`
- `mypy`
- `pytest tests/test_api.py::test_run_task_group_header tests/test_api.py::test_schedule_task_group_header tests/test_orchestrator.py::test_pipeline_group_id`


------
https://chatgpt.com/codex/tasks/task_e_688ebb51c2088326a8e3399313ebb9fc