### PR TITLE
Add financial decision support workflow

### DIFF
--- a/task_cascadence/workflows/__init__.py
+++ b/task_cascadence/workflows/__init__.py
@@ -26,3 +26,4 @@ def dispatch(event: str, *args: Any, **kwargs: Any) -> Any:
 
 # Import built-in workflows so they register themselves
 from . import calendar_event_creation  # noqa: F401,E402
+from . import financial_decision_support  # noqa: F401,E402

--- a/task_cascadence/workflows/financial_decision_support.py
+++ b/task_cascadence/workflows/financial_decision_support.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from . import subscribe, dispatch
+from ..http_utils import request_with_retry
+from ..ume import emit_stage_update_event
+
+
+@subscribe("finance.decision.request")
+def financial_decision_support(
+    payload: Dict[str, Any],
+    *,
+    user_id: str,
+    ume_base: str = "http://ume",
+    engine_base: str = "http://finance-engine",
+) -> Dict[str, Any]:
+    """Aggregate financial data, run a debt simulation, and persist results."""
+
+    url = f"{ume_base.rstrip('/')}/v1/nodes"
+    resp = request_with_retry(
+        "GET", url, params={"types": "FinancialAccount,FinancialGoal,DecisionAnalysis"}, timeout=5
+    )
+    data = resp.json()
+    nodes: List[Dict[str, Any]] = data.get("nodes", [])
+
+    accounts = [n for n in nodes if n.get("type") == "FinancialAccount"]
+    goals = [n for n in nodes if n.get("type") == "FinancialGoal"]
+    analyses = [n for n in nodes if n.get("type") == "DecisionAnalysis"]
+
+    total_balance = sum(a.get("balance", 0) for a in accounts)
+
+    engine_payload = {"balance": total_balance, "goals": goals, "analyses": analyses}
+    eng_resp = request_with_retry(
+        "POST", f"{engine_base.rstrip('/')}/v1/simulations/debt", json=engine_payload, timeout=5
+    )
+    eng_result = eng_resp.json()
+
+    analysis_id = eng_result.get("id", "analysis")
+    actions: List[Dict[str, Any]] = eng_result.get("actions", [])
+    nodes_to_persist = [
+        {
+            "id": analysis_id,
+            "type": "DecisionAnalysis",
+            "metrics": {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)},
+        }
+    ]
+    edges = []
+
+    for act in actions:
+        act_id = act.get("id")
+        nodes_to_persist.append(
+            {
+                "id": act_id,
+                "type": "ProposedAction",
+                "metrics": {"cost_of_deviation": act.get("cost_of_deviation")},
+            }
+        )
+        edges.append({"src": analysis_id, "dst": act_id, "type": "CONSIDERS"})
+        if accounts:
+            edges.append({"src": act_id, "dst": accounts[0].get("id"), "type": "OWNED_BY"})
+
+    request_with_retry("POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5)
+
+    if payload.get("explain"):
+        dispatch("finance.explain.request", {"analysis": analysis_id, "actions": actions}, user_id=user_id)
+
+    emit_stage_update_event("finance.decision.result", "completed", user_id=user_id)
+
+    return {"analysis": analysis_id, "actions": actions}

--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -1,0 +1,82 @@
+from task_cascadence.workflows import dispatch
+from task_cascadence.workflows import financial_decision_support as fds
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_financial_decision_support(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, timeout, **kwargs):
+        calls.append((method, url, kwargs))
+        if method == "GET":
+            return DummyResponse(
+                {
+                    "nodes": [
+                        {"id": "acct1", "type": "FinancialAccount", "balance": 1000},
+                        {"id": "acct2", "type": "FinancialAccount", "balance": 500},
+                        {"id": "goal1", "type": "FinancialGoal", "target": 2000},
+                        {"id": "da0", "type": "DecisionAnalysis"},
+                    ]
+                }
+            )
+        elif url.endswith("/v1/simulations/debt"):
+            assert kwargs["json"]["balance"] == 1500
+            assert len(kwargs["json"]["goals"]) == 1
+            assert len(kwargs["json"]["analyses"]) == 1
+            return DummyResponse(
+                {
+                    "id": "da1",
+                    "cost_of_deviation": 50,
+                    "actions": [
+                        {"id": "act1", "cost_of_deviation": 20},
+                    ],
+                }
+            )
+        else:  # persistence call
+            return DummyResponse({"ok": True})
+
+    emitted = {}
+
+    def fake_emit(name, stage, user_id=None, **_):
+        emitted["event"] = (name, stage, user_id)
+
+    explains = {}
+
+    def fake_dispatch(event, payload, user_id=None):
+        explains["called"] = (event, payload, user_id)
+
+    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
+    monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+
+    result = dispatch("finance.decision.request", {"explain": True}, user_id="alice")
+
+    # ensure UME query
+    assert calls[0][0] == "GET"
+    assert "FinancialAccount" in calls[0][2]["params"]["types"]
+
+    # engine call
+    assert calls[1][0] == "POST"
+    assert calls[1][1].endswith("/v1/simulations/debt")
+
+    # persistence call with metrics and edges
+    persist = calls[2][2]["json"]
+    assert any(
+        n["type"] == "DecisionAnalysis" and n["metrics"]["cost_of_deviation"] == 50
+        for n in persist["nodes"]
+    )
+    assert any(
+        n["type"] == "ProposedAction" and n["metrics"]["cost_of_deviation"] == 20
+        for n in persist["nodes"]
+    )
+    assert {"src": "da1", "dst": "act1", "type": "CONSIDERS"} in persist["edges"]
+    assert emitted["event"] == ("finance.decision.result", "completed", "alice")
+    assert explains["called"][0] == "finance.explain.request"
+    assert result["analysis"] == "da1"


### PR DESCRIPTION
## Summary
- implement `finance.decision.request` workflow that aggregates financial data, runs debt simulations, persists analysis/actions, and emits decision events
- register workflow for dispatch and add unit tests

## Testing
- `ruff check task_cascadence/workflows/financial_decision_support.py tests/test_financial_decision_support.py`
- `mypy task_cascadence/workflows/financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py tests/test_calendar_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec0a973208326ae36de96b4b9ede0