### PR TITLE
Add audit log emitter and extend pipeline logging

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -83,9 +83,12 @@ def run_task(
     """Execute ``name`` and return its result."""
     sched = get_default_scheduler()
     try:
-        result = sched.run_task(
-            name, use_temporal=temporal, user_id=user_id, group_id=group_id
-        )
+        kwargs: dict[str, Any] = {"use_temporal": temporal}
+        if user_id is not None:
+            kwargs["user_id"] = user_id
+        if group_id is not None:
+            kwargs["group_id"] = group_id
+        result = sched.run_task(name, **kwargs)
         return {"result": result}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -101,9 +104,12 @@ async def run_task_async(
     """Execute ``name`` asynchronously and return its result."""
     sched = get_default_scheduler()
     try:
-        result = sched.run_task(
-            name, use_temporal=temporal, user_id=user_id, group_id=group_id
-        )
+        kwargs: dict[str, Any] = {"use_temporal": temporal}
+        if user_id is not None:
+            kwargs["user_id"] = user_id
+        if group_id is not None:
+            kwargs["group_id"] = group_id
+        result = sched.run_task(name, **kwargs)
         if inspect.isawaitable(result):
             result = await result
         return {"result": result}

--- a/task_cascadence/pointer_store.py
+++ b/task_cascadence/pointer_store.py
@@ -69,10 +69,13 @@ class PointerStore:
         pointers.append(entry)
         self._save()
         try:
-            emit_pointer_update(
-                PointerUpdate(task_name=task_name, run_id=run_id, user_hash=user_hash),
-                user_id=user_id,
+            update = PointerUpdate(
+                task_name=task_name, run_id=run_id, user_hash=user_hash
             )
+            if group_id is not None:
+                emit_pointer_update(update, group_id=group_id)
+            else:
+                emit_pointer_update(update)
         except Exception:  # pragma: no cover - best effort transport
             pass
 

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -154,7 +154,14 @@ class BaseScheduler:
                         started_at=started,
                         finished_at=finished,
                     )
-                    emit_task_run(run, user_id=user_id, group_id=group_id)
+                    if user_id is None and group_id is None:
+                        emit_task_run(run)
+                    elif group_id is None:
+                        emit_task_run(run, user_id=user_id)
+                    elif user_id is None:
+                        emit_task_run(run, group_id=group_id)
+                    else:
+                        emit_task_run(run, user_id=user_id, group_id=group_id)
                 return result
 
             return runner()

--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -75,16 +75,28 @@ class StageStore:
         stage: str,
         user_id: str | None,
         group_id: str | None = None,
+        *,
+        status: str | None = None,
+        reason: str | None = None,
+        output: str | None = None,
+        category: str = "stage",
     ) -> None:
         entry: Dict[str, Any] = {
             "stage": stage,
             "time": datetime.now(timezone.utc).isoformat(),
         }
+        if status is not None:
+            entry["status"] = status
+        if reason is not None:
+            entry["reason"] = reason
+        if output is not None:
+            entry["output"] = output
         if user_id is not None:
             entry["user_id"] = user_id
         if group_id is not None:
             entry["group_id"] = group_id
-        events = self._data.setdefault(task_name, [])
+        key = task_name if category == "stage" else f"{task_name}:{category}"
+        events = self._data.setdefault(key, [])
         events.append(entry)
         self._save()
 
@@ -93,8 +105,11 @@ class StageStore:
         task_name: str,
         user_id: str | None = None,
         group_id: str | None = None,
+        *,
+        category: str = "stage",
     ) -> List[Dict[str, Any]]:
-        events = self._data.get(task_name, [])
+        key = task_name if category == "stage" else f"{task_name}:{category}"
+        events = self._data.get(key, [])
         return [
             e
             for e in events

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,38 @@
+import pytest
+
+from task_cascadence.stage_store import StageStore
+from task_cascadence.orchestrator import TaskPipeline
+
+
+class FailingTask:
+    def run(self):
+        raise RuntimeError("boom")
+
+
+def test_audit_log_persists_and_captures_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+    # reset singleton cache
+    import task_cascadence.ume as ume
+
+    ume._stage_store = None
+
+    pipeline = TaskPipeline(FailingTask())
+    monkeypatch.setattr(
+        "task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None
+    )
+    with pytest.raises(RuntimeError):
+        pipeline.execute()
+
+    store = StageStore()
+    events = store.get_events("FailingTask", category="audit")
+    # ensure failure recorded
+    failure = [e for e in events if e.get("status") == "error"]
+    assert failure and "boom" in failure[0]["reason"]
+
+    # simulate restart by creating new store instance
+    ume._stage_store = None
+    store2 = StageStore()
+    assert store2.get_events("FailingTask", category="audit") == events


### PR DESCRIPTION
## Summary
- track status, reasons and outputs for pipeline events
- emit audit logs for state transitions
- cover audit log persistence on restart

## Testing
- `ruff check task_cascadence/orchestrator.py task_cascadence/scheduler/__init__.py task_cascadence/suggestions/engine.py task_cascadence/ume/__init__.py task_cascadence/pointer_store.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec0aa04e48326bbb30c089eb51f7f