### PR TITLE
Add YAML schedule loading and calendar recurrence

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -265,6 +265,22 @@ def show_schedules() -> None:
         typer.echo(f"{name}\t{expr}")
 
 
+@app.command("load-schedules")
+def load_schedules(path: str) -> None:
+    """Load cron schedules from a YAML file."""
+
+    sched = get_default_scheduler()
+    if not isinstance(sched, CronScheduler):
+        typer.echo("error: scheduler lacks cron capabilities", err=True)
+        raise typer.Exit(code=1)
+    try:
+        sched.load_yaml(path)
+        typer.echo(f"loaded schedules from {path}")
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
 @app.command("replay-history")
 def replay_history(path: str) -> None:
     """Replay a workflow history from ``PATH``."""

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -1,0 +1,37 @@
+import yaml
+from task_cascadence.scheduler import CronScheduler
+
+
+class DummyTask:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def run(self) -> None:
+        self.count += 1
+
+
+def test_load_yaml_schedule(tmp_path):
+    data = {
+        "DummyTask": {
+            "expr": "* * * * *",
+            "recurrence": {"note": "every minute"},
+        }
+    }
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+    sched.load_yaml(cfg, {"DummyTask": task})
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+    assert sched.schedules["DummyTask"]["recurrence"] == {"note": "every minute"}
+
+
+def test_schedule_from_calendar_event(tmp_path):
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+    event = {"title": "review", "recurrence": {"cron": "*/2 * * * *"}}
+    sched.schedule_from_event(task, event)
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+    assert sched.schedules["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}


### PR DESCRIPTION
## Summary
- load cron schedules from external YAML files and persist recurrence metadata
- schedule tasks from calendar event recurrence information
- expose `load-schedules` CLI command for YAML configuration
- test YAML schedule parsing and calendar recurrence linkage

## Testing
- `ruff check .`
- `pytest tests/test_yaml_schedule.py tests/test_scheduler.py tests/test_cli.py tests/test_calendar_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_688f89d72d908326be592ee4ee513ec1