### PR TITLE
Enhance calendar event workflow with travel-time linking

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+import asyncio
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
 
 from . import subscribe
 from ..http_utils import request_with_retry
@@ -8,37 +10,101 @@ from .. import research
 from ..ume import emit_stage_update_event
 
 
-def _has_permission(user_id: str, *, ume_base: str = "http://ume") -> bool:
+def _has_permission(
+    user_id: str,
+    *,
+    ume_base: str = "http://ume",
+    group_id: str | None = None,
+    invitee: str | None = None,
+) -> bool:
     """Return ``True`` if ``user_id`` may create calendar events."""
 
     url = f"{ume_base.rstrip('/')}/v1/permissions/calendar:create"
-    resp = request_with_retry("GET", url, params={"user_id": user_id}, timeout=5)
+    params: Dict[str, Any] = {"user_id": user_id}
+    if group_id is not None:
+        params["group_id"] = group_id
+    if invitee is not None:
+        params["invitee"] = invitee
+    resp = request_with_retry("GET", url, params=params, timeout=5)
     data = resp.json()
     return bool(data.get("allowed"))
 
 
-@subscribe("calendar.event.create")
+@subscribe("calendar.event.create_request")
 def create_calendar_event(
-    payload: Dict[str, Any], *, user_id: str, base_url: str = "http://localhost"
+    payload: Dict[str, Any], *, user_id: str, base_url: str = "http://localhost", ume_base: str = "http://ume"
 ) -> Dict[str, Any]:
     """Persist a calendar event after validation and permission checks."""
 
-    for field in ("title", "start", "end"):
-        if field not in payload:
+    for field in ("title", "start_time"):
+        if field not in payload or not payload[field]:
             raise ValueError(f"missing required field: {field}")
-    if not _has_permission(user_id):
+
+    if not _has_permission(user_id, ume_base=ume_base):
         raise PermissionError("user lacks calendar:create permission")
 
+    group_id = payload.get("group_id")
+    if group_id and not _has_permission(user_id, ume_base=ume_base, group_id=group_id):
+        raise PermissionError("user lacks group permission")
+
+    invitees: List[str] = payload.get("invitees", []) or []
+    for invitee in invitees:
+        if not _has_permission(user_id, ume_base=ume_base, invitee=invitee):
+            raise PermissionError(f"user lacks permission to invite {invitee}")
+
     event_data = dict(payload)
+    event_data["user_id"] = user_id
+    if group_id:
+        event_data["group_id"] = group_id
+
+    related_event: Dict[str, Any] | None = None
     if payload.get("location"):
         try:
-            event_data["travel_time"] = research.gather(
-                f"travel time to {payload['location']}"
+            travel_info = asyncio.run(
+                research.async_gather(f"travel time to {payload['location']}")
             )
+            event_data["travel_time"] = travel_info
+            start_dt = datetime.fromisoformat(payload["start_time"].replace("Z", "+00:00"))
+            duration = travel_info.get("duration")
+            leave_dt = start_dt
+            if isinstance(duration, str) and duration.endswith("m"):
+                leave_dt = start_dt - timedelta(minutes=int(duration[:-1]))
+            related_event = {
+                "title": f"Leave by {payload['title']}",
+                "start_time": leave_dt.isoformat(),
+                "user_id": user_id,
+            }
+            if group_id:
+                related_event["group_id"] = group_id
         except RuntimeError:
             pass
 
     url = f"{base_url.rstrip('/')}/v1/calendar/events"
     resp = request_with_retry("POST", url, json=event_data, timeout=5)
-    emit_stage_update_event("calendar.event.created", "created", user_id=user_id)
-    return resp.json()
+    main_event = resp.json()
+    main_id = main_event.get("id")
+
+    related_id = None
+    if related_event is not None:
+        rel_resp = request_with_retry("POST", url, json=related_event, timeout=5)
+        related_event = rel_resp.json()
+        related_id = related_event.get("id")
+        edge_url = f"{base_url.rstrip('/')}/v1/calendar/edges"
+        edge_payload = {
+            "src": related_id,
+            "dst": main_id,
+            "type": "RELATES_TO",
+            "user_id": user_id,
+        }
+        if group_id:
+            edge_payload["group_id"] = group_id
+        request_with_retry("POST", edge_url, json=edge_payload, timeout=5)
+
+    emit_stage_update_event(
+        "calendar.event.created", "created", user_id=user_id, group_id=group_id
+    )
+
+    result: Dict[str, Any] = {"event_id": main_id}
+    if related_id:
+        result["related_event_id"] = related_id
+    return result

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -12,41 +12,57 @@ class DummyResponse:
 
 def test_calendar_event_creation(monkeypatch):
     calls = []
+    counter = {"post": 0}
 
     def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             return DummyResponse({"allowed": True})
-        assert method == "POST"
-        return DummyResponse({"id": "evt1"})
+        if url.endswith("/edges"):
+            return DummyResponse({"ok": True})
+        counter["post"] += 1
+        return DummyResponse({"id": f"evt{counter['post']}"})
 
     emitted = {}
 
-    def fake_emit(name, stage, user_id=None, **_kwargs):
-        emitted["event"] = (name, stage, user_id)
+    def fake_emit(name, stage, user_id=None, group_id=None, **_kwargs):
+        emitted["event"] = (name, stage, user_id, group_id)
 
-    def fake_research(query):
+    async def fake_async_gather(query):
         emitted["research"] = query
         return {"duration": "15m"}
 
     monkeypatch.setattr(cec, "request_with_retry", fake_request)
     monkeypatch.setattr(cec, "emit_stage_update_event", fake_emit)
-    monkeypatch.setattr(cec.research, "gather", fake_research)
+    monkeypatch.setattr(cec.research, "async_gather", fake_async_gather)
 
     payload = {
         "title": "Lunch",
-        "start": "2024-01-01T12:00:00Z",
-        "end": "2024-01-01T13:00:00Z",
+        "start_time": "2024-01-01T12:00:00Z",
         "location": "Cafe",
+        "group_id": "g1",
+        "invitees": ["bob"],
     }
 
-    result = dispatch("calendar.event.create", payload, user_id="alice", base_url="http://svc")
+    result = dispatch(
+        "calendar.event.create_request", payload, user_id="alice", base_url="http://svc"
+    )
 
-    assert result == {"id": "evt1"}
+    assert result == {"event_id": "evt1", "related_event_id": "evt2"}
+    # permission checks
     assert calls[0][0] == "GET"
-    assert "permissions" in calls[0][1]
-    assert calls[1][0] == "POST"
-    assert calls[1][1] == "http://svc/v1/calendar/events"
-    assert calls[1][2]["json"]["travel_time"] == {"duration": "15m"}
-    assert emitted["event"] == ("calendar.event.created", "created", "alice")
+    assert calls[1][0] == "GET" and calls[1][2]["params"]["group_id"] == "g1"
+    assert calls[2][0] == "GET" and calls[2][2]["params"]["invitee"] == "bob"
+    # main event persisted
+    assert calls[3][0] == "POST"
+    assert calls[3][1] == "http://svc/v1/calendar/events"
+    assert calls[3][2]["json"]["user_id"] == "alice"
+    assert calls[3][2]["json"]["group_id"] == "g1"
+    assert calls[3][2]["json"]["travel_time"] == {"duration": "15m"}
+    # related event persisted
+    assert calls[4][0] == "POST" and calls[4][1] == "http://svc/v1/calendar/events"
+    # edge creation
+    assert calls[5][0] == "POST" and calls[5][1] == "http://svc/v1/calendar/edges"
+    assert calls[5][2]["json"]["type"] == "RELATES_TO"
+    assert emitted["event"] == ("calendar.event.created", "created", "alice", "g1")
     assert emitted["research"] == "travel time to Cafe"


### PR DESCRIPTION
## Summary
- support `calendar.event.create_request` events with explicit validation and UME-based permission checks
- create paired “Leave by” events when locations are provided, linking them via `RELATES_TO`
- expose comprehensive test coverage for the workflow

## Testing
- `ruff check`
- `pytest tests/test_calendar_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_688fca81372c832680e85383f8448878