### PR TITLE
Propagate user context into research helpers

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -271,11 +271,19 @@ def suggestion_dismiss(
 
 
 @app.post("/intent", response_model=IntentResponse)
-def intent_route(req: IntentRequest):
+def intent_route(
+    req: IntentRequest,
+    user_id: str | None = Depends(get_user_id),
+    group_id: str | None = Depends(get_group_id),
+):
     """Return intent analysis for the provided message."""
+    if user_id is None:
+        raise HTTPException(400, "user_id header required")
     message = sanitize_input(req.message)
     ctx = [sanitize_input(c) for c in req.context]
-    result = resolve_intent(message, ctx)
+    result = resolve_intent(
+        message, ctx, user_id=user_id, group_id=group_id
+    )
     return IntentResponse(
         task=result.task,
         arguments=result.arguments,

--- a/task_cascadence/intent.py
+++ b/task_cascadence/intent.py
@@ -62,14 +62,19 @@ def _build_prompt(message: str, context: List[str]) -> str:
 
 
 def resolve_intent(
-    message: str, context: Optional[List[str]] = None, *, threshold: float = CLARIFICATION_THRESHOLD
+    message: str,
+    context: Optional[List[str]] = None,
+    *,
+    threshold: float = CLARIFICATION_THRESHOLD,
+    user_id: str,
+    group_id: str | None = None,
 ) -> IntentResult:
     """Return the :class:`IntentResult` for *message* using *context* for disambiguation."""
 
     ctx = [sanitize_input(c) for c in (context or [])]
     message = sanitize_input(message)
     prompt = _build_prompt(message, ctx)
-    result = gather(prompt)
+    result = gather(prompt, user_id=user_id, group_id=group_id)
     task: Optional[str] = None
     args: Dict[str, Any] = {}
     confidence = 0.0

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -109,7 +109,9 @@ class TaskPipeline:
                 if inspect.isawaitable(q):
                     q = await q
                 try:
-                    result = await research.async_gather(q)
+                    result = await research.async_gather(
+                        q, user_id=user_id or "", group_id=group_id
+                    )
                 except RuntimeError:
                     self._emit_stage("research", user_id, group_id)
                     return None
@@ -123,7 +125,9 @@ class TaskPipeline:
         if loop_running:
             async def _async_call() -> Any:
                 try:
-                    result = await research.async_gather(query)
+                    result = await research.async_gather(
+                        query, user_id=user_id or "", group_id=group_id
+                    )
                 except RuntimeError:
                     self._emit_stage("research", user_id, group_id)
                     return None
@@ -133,7 +137,9 @@ class TaskPipeline:
             return _async_call()
 
         try:
-            result = research.gather(query)
+            result = research.gather(
+                query, user_id=user_id or "", group_id=group_id
+            )
         except RuntimeError:
             self._emit_stage("research", user_id, group_id)
             return None

--- a/task_cascadence/research.py
+++ b/task_cascadence/research.py
@@ -9,37 +9,55 @@ try:
     import tino_storm  # type: ignore
 except Exception:  # pragma: no cover - optional dependency may be missing
     tino_storm = None  # type: ignore
+def gather(query: str, user_id: str, group_id: str | None = None) -> Any:
+    """Return research information for ``query`` using ``tino_storm``.
 
-
-def gather(query: str) -> Any:
-    """Return research information for ``query`` using ``tino_storm``."""
+    Parameters are forwarded to ``tino_storm`` if supported.
+    """
     if tino_storm is None:  # pragma: no cover - runtime behaviour
-        raise RuntimeError("tino_storm is not installed")
+        raise RuntimeError(f"tino_storm is not installed for user {user_id}")
 
     if hasattr(tino_storm, "search"):
-        return tino_storm.search(query)
+        func = tino_storm.search
+    elif callable(tino_storm):
+        func = tino_storm
+    else:
+        raise RuntimeError(f"Unsupported tino_storm interface for user {user_id}")
 
-    if callable(tino_storm):
-        return tino_storm(query)
+    params = inspect.signature(func).parameters
+    kwargs: dict[str, Any] = {}
+    if "user_id" in params:
+        kwargs["user_id"] = user_id
+    if "group_id" in params and group_id is not None:
+        kwargs["group_id"] = group_id
+    return func(query, **kwargs)
 
-    raise RuntimeError("Unsupported tino_storm interface")
 
-
-async def async_gather(query: str) -> Any:
+async def async_gather(
+    query: str, user_id: str, group_id: str | None = None
+) -> Any:
     """Asynchronously return research information for ``query`` using ``tino_storm``.
 
     If the call to ``tino_storm`` returns a coroutine it will be awaited.
     """
     if tino_storm is None:  # pragma: no cover - runtime behaviour
-        raise RuntimeError("tino_storm is not installed")
+        raise RuntimeError(f"tino_storm is not installed for user {user_id}")
 
     if hasattr(tino_storm, "search"):
-        result = tino_storm.search(query)
+        func = tino_storm.search
     elif callable(tino_storm):
-        result = tino_storm(query)
+        func = tino_storm
     else:
-        raise RuntimeError("Unsupported tino_storm interface")
+        raise RuntimeError(f"Unsupported tino_storm interface for user {user_id}")
 
+    params = inspect.signature(func).parameters
+    kwargs: dict[str, Any] = {}
+    if "user_id" in params:
+        kwargs["user_id"] = user_id
+    if "group_id" in params and group_id is not None:
+        kwargs["group_id"] = group_id
+
+    result = func(query, **kwargs)
     if inspect.isawaitable(result):
         return await result
     return result

--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -33,7 +33,7 @@ def create_calendar_event(
     if payload.get("location"):
         try:
             event_data["travel_time"] = research.gather(
-                f"travel time to {payload['location']}"
+                f"travel time to {payload['location']}", user_id=user_id
             )
         except RuntimeError:
             pass

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -25,8 +25,8 @@ def test_calendar_event_creation(monkeypatch):
     def fake_emit(name, stage, user_id=None, **_kwargs):
         emitted["event"] = (name, stage, user_id)
 
-    def fake_research(query):
-        emitted["research"] = query
+    def fake_research(query, user_id=None, group_id=None):
+        emitted["research"] = (query, user_id, group_id)
         return {"duration": "15m"}
 
     monkeypatch.setattr(cec, "request_with_retry", fake_request)
@@ -49,4 +49,4 @@ def test_calendar_event_creation(monkeypatch):
     assert calls[1][1] == "http://svc/v1/calendar/events"
     assert calls[1][2]["json"]["travel_time"] == {"duration": "15m"}
     assert emitted["event"] == ("calendar.event.created", "created", "alice")
-    assert emitted["research"] == "travel time to Cafe"
+    assert emitted["research"] == ("travel time to Cafe", "alice", None)

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -6,7 +6,7 @@ from task_cascadence.api import app
 def test_disambiguation_with_context(monkeypatch):
     captured = {}
 
-    def fake_gather(prompt: str):
+    def fake_gather(prompt: str, user_id: str, group_id: str | None = None):
         captured['prompt'] = prompt
         return {
             'task': 'send_email',
@@ -19,6 +19,7 @@ def test_disambiguation_with_context(monkeypatch):
     resp = client.post(
         '/intent',
         json={'message': 'Schedule it for tomorrow', 'context': ['send email to bob@example.com']},
+        headers={'X-User-ID': 'u1'}
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -29,12 +30,12 @@ def test_disambiguation_with_context(monkeypatch):
 
 
 def test_clarification_triggered(monkeypatch):
-    def fake_gather(prompt: str):
+    def fake_gather(prompt: str, user_id: str, group_id: str | None = None):
         return {'task': None, 'arguments': {}, 'confidence': 0.2}
 
     monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
     client = TestClient(app)
-    resp = client.post('/intent', json={'message': 'do something', 'context': []})
+    resp = client.post('/intent', json={'message': 'do something', 'context': []}, headers={'X-User-ID': 'u1'})
     assert resp.status_code == 200
     data = resp.json()
     assert data['clarification']
@@ -44,14 +45,14 @@ def test_clarification_triggered(monkeypatch):
 def test_sanitization_prevents_injection(monkeypatch):
     captured = {}
 
-    def fake_gather(prompt: str):
+    def fake_gather(prompt: str, user_id: str, group_id: str | None = None):
         captured['prompt'] = prompt
         return {'task': 'noop', 'arguments': {}, 'confidence': 1.0}
 
     monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
     client = TestClient(app)
     malicious = "<script>alert('x')</script>; rm -rf / 4111111111111111 bob@example.com"
-    resp = client.post('/intent', json={'message': malicious, 'context': []})
+    resp = client.post('/intent', json={'message': malicious, 'context': []}, headers={'X-User-ID': 'u1'})
     assert resp.status_code == 200
     prompt = captured['prompt']
     assert '<script>' not in prompt

--- a/tests/test_research_gather.py
+++ b/tests/test_research_gather.py
@@ -10,7 +10,7 @@ def test_gather_with_search(monkeypatch):
             return f"result:{query}"
 
     monkeypatch.setattr(research, "tino_storm", Stub())
-    assert research.gather("foo") == "result:foo"
+    assert research.gather("foo", user_id="u1") == "result:foo"
 
 
 def test_gather_with_callable(monkeypatch):
@@ -18,37 +18,40 @@ def test_gather_with_callable(monkeypatch):
         return f"call:{query}"
 
     monkeypatch.setattr(research, "tino_storm", func)
-    assert research.gather("bar") == "call:bar"
+    assert research.gather("bar", user_id="u1") == "call:bar"
 
 
 def test_gather_invalid_interface(monkeypatch):
     monkeypatch.setattr(research, "tino_storm", object())
     with pytest.raises(RuntimeError):
-        research.gather("oops")
+        research.gather("oops", user_id="u1")
 
 
 def test_async_gather_search_returns_coroutine(monkeypatch):
     class Stub:
-        async def search(self, query):
+        async def search(self, query, user_id=None, group_id=None):
             await asyncio.sleep(0)
+            assert user_id == "u1"
+            assert group_id == "g1"
             return f"async:{query}"
 
     monkeypatch.setattr(research, "tino_storm", Stub())
-    result = asyncio.run(research.async_gather("abc"))
+    result = asyncio.run(research.async_gather("abc", user_id="u1", group_id="g1"))
     assert result == "async:abc"
 
 
 def test_async_gather_callable_returns_coroutine(monkeypatch):
-    async def func(query):
+    async def func(query, user_id=None):
         await asyncio.sleep(0)
+        assert user_id == "u1"
         return f"coro:{query}"
 
     monkeypatch.setattr(research, "tino_storm", func)
-    result = asyncio.run(research.async_gather("xyz"))
+    result = asyncio.run(research.async_gather("xyz", user_id="u1"))
     assert result == "coro:xyz"
 
 
 def test_async_gather_invalid_interface(monkeypatch):
     monkeypatch.setattr(research, "tino_storm", object())
     with pytest.raises(RuntimeError):
-        asyncio.run(research.async_gather("fail"))
+        asyncio.run(research.async_gather("fail", user_id="u1"))

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -23,9 +23,9 @@ async def _prepare_engine(monkeypatch, events=None, tmp_path=None):
     monkeypatch.setattr(engine, "_query_ume", fake_query)
     monkeypatch.setattr(
         "task_cascadence.suggestions.engine.gather",
-        lambda q: {"confidence": 0.9},
+        lambda q, user_id, group_id=None: {"confidence": 0.9},
     )
-    await engine.generate()
+    await engine.generate(user_id="alice")
     return engine
 
 


### PR DESCRIPTION
## Summary
- allow research.gather and async_gather to accept `user_id` and `group_id` and forward them to `tino_storm`
- plumb user/group context through intent resolution, task pipeline research, suggestion generation, and calendar workflow
- require `X-User-ID` header on the intent API endpoint
- update calendar workflow test to assert user context is passed to research helpers

## Testing
- `ruff check task_cascadence tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fca80a7d0832684d5514ec20d1fea