### PR TITLE
feat: extend financial decision support

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -38,7 +38,7 @@ def create_calendar_event(
     payload: Dict[str, Any], *, user_id: str, base_url: str = "http://localhost", ume_base: str = "http://ume"
 
 ) -> Dict[str, Any]:
-    """Persist calendar events after validation and permission checks.
+    """Persist calendar events after validation and permission checks."""
 
     for field in ("title", "start_time"):
         if field not in payload or not payload[field]:

--- a/task_cascadence/workflows/financial_decision_support.py
+++ b/task_cascadence/workflows/financial_decision_support.py
@@ -17,10 +17,16 @@ def financial_decision_support(
 ) -> Dict[str, Any]:
     """Aggregate financial data, run a debt simulation, and persist results."""
 
+    group_id = payload.get("group_id")
+
     url = f"{ume_base.rstrip('/')}/v1/nodes"
-    resp = request_with_retry(
-        "GET", url, params={"types": "FinancialAccount,FinancialGoal,DecisionAnalysis"}, timeout=5
-    )
+    params: Dict[str, Any] = {
+        "types": "FinancialAccount,FinancialGoal,DecisionAnalysis",
+        "user_id": user_id,
+    }
+    if group_id is not None:
+        params["group_id"] = group_id
+    resp = request_with_retry("GET", url, params=params, timeout=5)
     data = resp.json()
     nodes: List[Dict[str, Any]] = data.get("nodes", [])
 
@@ -31,6 +37,10 @@ def financial_decision_support(
     total_balance = sum(a.get("balance", 0) for a in accounts)
 
     engine_payload = {"balance": total_balance, "goals": goals, "analyses": analyses}
+    if "budget" in payload:
+        engine_payload["budget"] = payload["budget"]
+    if "max_options" in payload:
+        engine_payload["max_options"] = payload["max_options"]
     eng_resp = request_with_retry(
         "POST", f"{engine_base.rstrip('/')}/v1/simulations/debt", json=engine_payload, timeout=5
     )
@@ -43,28 +53,55 @@ def financial_decision_support(
             "id": analysis_id,
             "type": "DecisionAnalysis",
             "metrics": {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)},
+            "user_id": user_id,
         }
     ]
+    if group_id is not None:
+        nodes_to_persist[0]["group_id"] = group_id
     edges = []
 
     for act in actions:
         act_id = act.get("id")
-        nodes_to_persist.append(
-            {
-                "id": act_id,
-                "type": "ProposedAction",
-                "metrics": {"cost_of_deviation": act.get("cost_of_deviation")},
-            }
-        )
-        edges.append({"src": analysis_id, "dst": act_id, "type": "CONSIDERS"})
+        node = {
+            "id": act_id,
+            "type": "ProposedAction",
+            "metrics": {"cost_of_deviation": act.get("cost_of_deviation")},
+            "user_id": user_id,
+        }
+        if group_id is not None:
+            node["group_id"] = group_id
+        nodes_to_persist.append(node)
+        edge = {"src": analysis_id, "dst": act_id, "type": "CONSIDERS", "user_id": user_id}
+        if group_id is not None:
+            edge["group_id"] = group_id
+        edges.append(edge)
         if accounts:
-            edges.append({"src": act_id, "dst": accounts[0].get("id"), "type": "OWNED_BY"})
+            owned_edge = {
+                "src": act_id,
+                "dst": accounts[0].get("id"),
+                "type": "OWNED_BY",
+                "user_id": user_id,
+            }
+            if group_id is not None:
+                owned_edge["group_id"] = group_id
+            edges.append(owned_edge)
 
     request_with_retry("POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5)
 
+    summary = {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)}
+    context = {"analysis": analysis_id, "summary": summary}
+
+    dispatch("finance.decision.result", context, user_id=user_id, group_id=group_id)
     if payload.get("explain"):
-        dispatch("finance.explain.request", {"analysis": analysis_id, "actions": actions}, user_id=user_id)
+        dispatch(
+            "finance.explain.request",
+            {**context, "actions": actions},
+            user_id=user_id,
+            group_id=group_id,
+        )
 
-    emit_stage_update_event("finance.decision.result", "completed", user_id=user_id)
+    emit_stage_update_event(
+        "finance.decision.result", "completed", user_id=user_id, group_id=group_id
+    )
 
-    return {"analysis": analysis_id, "actions": actions}
+    return {**context, "actions": actions}


### PR DESCRIPTION
## Summary
- scope financial queries by user and optional group
- forward budget and option limits to finance engine
- persist decision analysis results and emit summary events

## Testing
- `ruff check task_cascadence/workflows/financial_decision_support.py task_cascadence/workflows/calendar_event_creation.py tests/test_financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fceda06248326b4d03246486bd274