### PR TITLE
Handle context in schedule_from_event

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -428,13 +428,20 @@ class CronScheduler(BaseScheduler):
         if not expr:
             raise ValueError("event missing recurrence cron")
 
-        self.register_task(task, expr)
+        user_id = event.get("user_id")
+        group_id = event.get("group_id")
+        self.register_task(task, expr, user_id=user_id, group_id=group_id)
         job_id = task.__class__.__name__
         sched_entry = self.schedules.get(job_id)
         if isinstance(sched_entry, dict):
             sched_entry["recurrence"] = recurrence
         else:
-            self.schedules[job_id] = {"expr": expr, "recurrence": recurrence}
+            entry: dict[str, Any] = {"expr": expr, "recurrence": recurrence}
+            if user_id is not None:
+                entry["user_id"] = user_id
+            if group_id is not None:
+                entry["group_id"] = group_id
+            self.schedules[job_id] = entry
         self._save_schedules()
 
     def unschedule(self, name: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from task_cascadence import scheduler as scheduler_module
+import task_cascadence.scheduler as scheduler_module
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -30,8 +30,22 @@ def test_load_yaml_schedule(tmp_path):
 def test_schedule_from_calendar_event(tmp_path):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
-    event = {"title": "review", "recurrence": {"cron": "*/2 * * * *"}}
+    event = {
+        "title": "review",
+        "user_id": "alice",
+        "group_id": "devs",
+        "recurrence": {"cron": "*/2 * * * *"},
+    }
     sched.schedule_from_event(task, event)
     job = sched.scheduler.get_job("DummyTask")
     assert job is not None
-    assert sched.schedules["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
+    entry = sched.schedules["DummyTask"]
+    assert entry["user_id"] == "alice"
+    assert entry["group_id"] == "devs"
+    assert entry["recurrence"] == {"cron": "*/2 * * * *"}
+
+    data = yaml.safe_load((tmp_path / "sched.yml").read_text())
+    yaml_entry = data["DummyTask"]
+    assert yaml_entry["user_id"] == "alice"
+    assert yaml_entry["group_id"] == "devs"
+    assert yaml_entry["recurrence"] == {"cron": "*/2 * * * *"}


### PR DESCRIPTION
## Summary
- ensure `schedule_from_event` registers tasks with `user_id` and `group_id`
- verify scheduled entry and YAML persistence include context and recurrence metadata
- load scheduler module directly in tests to avoid side effects

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/test_yaml_schedule.py tests/conftest.py`
- `pytest tests/test_yaml_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_689020962f048326824d3bcaed2deecb