### PR TITLE
Add user and group scheduling metadata

### DIFF
--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -31,7 +31,16 @@ def test_schedule_from_calendar_event(tmp_path):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
     event = {"title": "review", "recurrence": {"cron": "*/2 * * * *"}}
-    sched.schedule_from_event(task, event)
+    sched.schedule_from_event(
+        task, event, user_id="alice", group_id="engineering"
+    )
     job = sched.scheduler.get_job("DummyTask")
     assert job is not None
-    assert sched.schedules["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
+    entry = sched.schedules["DummyTask"]
+    assert entry["recurrence"] == {"cron": "*/2 * * * *"}
+    assert entry["user_id"] == "alice"
+    assert entry["group_id"] == "engineering"
+    persisted = yaml.safe_load((tmp_path / "sched.yml").read_text())
+    assert persisted["DummyTask"]["user_id"] == "alice"
+    assert persisted["DummyTask"]["group_id"] == "engineering"
+    assert persisted["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}


### PR DESCRIPTION
## Summary
- allow `CronScheduler.schedule_from_event` to accept `user_id` and `group_id`
- persist `user_id`, `group_id`, and recurrence in schedules and YAML
- test calendar scheduling with user and group metadata

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/test_yaml_schedule.py`
- `mypy task_cascadence/scheduler/__init__.py`
- `pytest tests/test_yaml_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_689020959f1c83268e3a10495baeea85