### PR TITLE
Dispatch calendar creation events

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+import asyncio
+import threading
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
-from . import subscribe
+from . import dispatch, subscribe
 from ..http_utils import request_with_retry
 from .. import research
 from ..ume import emit_stage_update_event, emit_task_note
@@ -163,9 +165,12 @@ def create_calendar_event(
         event_id=main_id,
 
     )
+    note = TaskNote(note=f"Created event {payload['title']}")
     emit_task_note(note, user_id=user_id, group_id=group_id)
 
     result: Dict[str, Any] = {"event_id": main_id}
     if related_id:
         result["related_event_id"] = related_id
+
+    dispatch("calendar.event.created", result, user_id=user_id, group_id=group_id)
     return result

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -1,5 +1,5 @@
 import asyncio
-
+from typing import Any
 
 from task_cascadence.workflows import dispatch
 from task_cascadence.workflows import calendar_event_creation as cec
@@ -26,7 +26,8 @@ def test_calendar_event_creation(monkeypatch):
         counter["post"] += 1
         return DummyResponse({"id": f"evt{counter['post']}"})
 
-    emitted = {}
+    emitted: dict[str, tuple[Any, ...]] = {}
+    dispatched: dict[str, tuple[Any, ...]] = {}
 
     def fake_emit(name, stage, user_id=None, group_id=None, **kwargs):
         emitted["event"] = (name, stage, user_id, group_id, kwargs.get("event_id"))
@@ -37,13 +38,22 @@ def test_calendar_event_creation(monkeypatch):
         return {"duration": "15m"}
 
     def fake_gather(query, user_id=None, group_id=None):
-        result = asyncio.run(fake_async_gather(query, user_id=user_id, group_id=group_id))
-        cec.travel_info = result
+        result = asyncio.run(
+            fake_async_gather(query, user_id=user_id, group_id=group_id)
+        )
+        cec.travel_info = result  # type: ignore[attr-defined]
         return result
 
     monkeypatch.setattr(cec, "request_with_retry", fake_request)
     monkeypatch.setattr(cec, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(cec.research, "gather", fake_gather)
+    monkeypatch.setattr(cec.research, "async_gather", fake_async_gather)
+    monkeypatch.setattr(cec, "emit_task_note", lambda *a, **kw: None)
+
+    def fake_dispatch(event, data, *, user_id=None, group_id=None):
+        dispatched["event"] = (event, data, user_id, group_id)
+
+    monkeypatch.setattr(cec, "dispatch", fake_dispatch)
 
 
     payload = {
@@ -85,4 +95,10 @@ def test_calendar_event_creation(monkeypatch):
         "evt1",
     )
     assert emitted["research"] == ("travel time to Cafe", "alice", None)
+    assert dispatched["event"] == (
+        "calendar.event.created",
+        result,
+        "alice",
+        "g1",
+    )
 


### PR DESCRIPTION
## Summary
- dispatch calendar.event.created after persisting events
- test dispatch payload in calendar workflow test
- stub research async gather in test and address typing

## Testing
- `pytest tests/test_calendar_workflow.py::test_calendar_event_creation -q`
- `ruff check task_cascadence/workflows/calendar_event_creation.py tests/test_calendar_workflow.py`
- `mypy task_cascadence/workflows/calendar_event_creation.py tests/test_calendar_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c6f308c88326a69425f141af7c8f