### PR TITLE
Refactor travel research handling

### DIFF
--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -119,8 +119,10 @@ class TaskPipeline:
         task_name = self.task.__class__.__name__
         emit_audit_log(task_name, "research", "started", user_id=user_id, group_id=group_id)
         if not hasattr(self.task, "research"):
-            # Tasks without a dedicated research step should skip this stage
-            # entirely so pipelines emit the standard ``planning`` stage next.
+            # Even if a task has no dedicated research step, emit the standard
+            # stage notification so downstream consumers observe a "research"
+            # phase was considered and skipped.
+            self._emit_stage("research", user_id, group_id)
             emit_audit_log(
                 task_name, "research", "skipped", user_id=user_id, group_id=group_id
             )

--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
+
+import asyncio
+import threading
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
+
 from . import subscribe
 from ..http_utils import request_with_retry
 from .. import research
@@ -43,21 +47,21 @@ def create_calendar_event(
 
     group_id = payload.get("group_id")
 
-    travel_holder: Dict[str, asyncio.Task] = {}
+    travel_task: asyncio.Task | None = None
     travel_thread: threading.Thread | None = None
     if payload.get("location"):
         loop = asyncio.new_event_loop()
 
         async def _inner() -> None:
-            task = asyncio.create_task(
+            nonlocal travel_task
+            travel_task = asyncio.create_task(
                 research.async_gather(
                     f"travel time to {payload['location']}",
                     user_id=user_id,
                     group_id=group_id,
                 )
             )
-            travel_holder["task"] = task
-            await task
+            await travel_task
 
         def _run() -> None:  # pragma: no cover - executed in thread
             asyncio.set_event_loop(loop)
@@ -88,15 +92,18 @@ def create_calendar_event(
 
     related_event: Dict[str, Any] | None = None
     travel_info: Dict[str, Any] | None = None
-    travel_task = travel_holder.get("task")
     if travel_task is not None:
         try:
-            travel_info = research.gather(
-                f"travel time to {payload['location']}", user_id=user_id
+            travel_info = travel_task.result()
+            research.gather(
+                f"travel time to {payload['location']}",
+                user_id=user_id,
+                group_id=group_id,
             )
-
             event_data["travel_time"] = travel_info
-            start_dt = datetime.fromisoformat(payload["start_time"].replace("Z", "+00:00"))
+            start_dt = datetime.fromisoformat(
+                payload["start_time"].replace("Z", "+00:00")
+            )
             duration = travel_info.get("duration")
             leave_dt = start_dt
             if isinstance(duration, str) and duration.endswith("m"):
@@ -108,8 +115,14 @@ def create_calendar_event(
             }
             if group_id:
                 related_event["group_id"] = group_id
-        except RuntimeError:
-            pass
+        except Exception:
+            travel_info = None
+
+    note_text = "No travel details"
+    if travel_info:
+        duration = travel_info.get("duration")
+        note_text = f"Travel time to {payload['location']}: {duration}"
+    note = TaskNote(note=note_text)
 
     url = f"{base_url.rstrip('/')}/v1/calendar/events"
     resp = request_with_retry("POST", url, json=event_data, timeout=5)

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -1,6 +1,3 @@
-import asyncio
-
-
 from task_cascadence.workflows import dispatch
 from task_cascadence.workflows import calendar_event_creation as cec
 
@@ -31,18 +28,21 @@ def test_calendar_event_creation(monkeypatch):
     def fake_emit(name, stage, user_id=None, group_id=None, **kwargs):
         emitted["event"] = (name, stage, user_id, group_id, kwargs.get("event_id"))
 
-
     async def fake_async_gather(query, user_id=None, group_id=None):
-        emitted["research"] = (query, user_id, group_id)
+        emitted["async_research"] = (query, user_id, group_id)
         return {"duration": "15m"}
 
     def fake_gather(query, user_id=None, group_id=None):
-        result = asyncio.run(fake_async_gather(query, user_id=user_id, group_id=group_id))
-        cec.travel_info = result
-        return result
+        emitted["gather"] = (query, user_id, group_id)
+        return {"duration": "15m"}
+
+    def fake_emit_note(note, user_id=None, group_id=None):
+        emitted["note"] = (note.note, user_id, group_id)
 
     monkeypatch.setattr(cec, "request_with_retry", fake_request)
     monkeypatch.setattr(cec, "emit_stage_update_event", fake_emit)
+    monkeypatch.setattr(cec, "emit_task_note", fake_emit_note)
+    monkeypatch.setattr(cec.research, "async_gather", fake_async_gather)
     monkeypatch.setattr(cec.research, "gather", fake_gather)
 
 
@@ -84,5 +84,7 @@ def test_calendar_event_creation(monkeypatch):
         "g1",
         "evt1",
     )
-    assert emitted["research"] == ("travel time to Cafe", "alice", None)
+    assert emitted["async_research"] == ("travel time to Cafe", "alice", "g1")
+    assert emitted["gather"] == ("travel time to Cafe", "alice", "g1")
+    assert emitted["note"] == ("Travel time to Cafe: 15m", "alice", "g1")
 


### PR DESCRIPTION
## Summary
- manage travel research with direct asyncio tasks and note emission
- cover new travel details in calendar workflow tests
- emit research stage notifications even when tasks skip the research step

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c6f3c5608326b580849689044d7c