### PR TITLE
Require explicit user identifiers for task operations

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -104,7 +104,7 @@ def list_tasks() -> None:
 def run_task(
     name: str,
     temporal: bool = typer.Option(False, "--temporal", help="Execute via Temporal"),
-    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+    user_id: str = typer.Option(..., "--user-id", help="User ID for UME events"),
 ) -> None:
     """Run ``NAME`` if it exists and is enabled."""
 
@@ -124,7 +124,7 @@ def run_task(
 def run_task_async(
     name: str,
     temporal: bool = typer.Option(False, "--temporal", help="Execute via Temporal"),
-    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+    user_id: str = typer.Option(..., "--user-id", help="User ID for UME events"),
 ) -> None:
     """Run ``NAME`` asynchronously if it exists and is enabled."""
 
@@ -148,7 +148,7 @@ def run_task_async(
 @app.command("trigger")
 def manual_trigger(
     name: str,
-    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+    user_id: str = typer.Option(..., "--user-id", help="User ID for UME events"),
 ) -> None:
     """Run ``NAME`` if it is a ManualTrigger task."""
 
@@ -209,7 +209,7 @@ def resume_task(name: str) -> None:
 def schedule_task(
     name: str,
     expression: str,
-    user_id: str | None = typer.Option(None, "--user-id", help="User ID for UME events"),
+    user_id: str = typer.Option(..., "--user-id", help="User ID for UME events"),
 ) -> None:
     """Schedule ``NAME`` according to ``EXPRESSION``."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,7 +79,7 @@ def test_list_tasks(monkeypatch, tmp_path):
 def test_run_task(monkeypatch, tmp_path):
     sched, task = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
-    resp = client.post("/tasks/dummy/run")
+    resp = client.post("/tasks/dummy/run", headers={"X-User-ID": "alice"})
     assert resp.status_code == 200
     assert resp.json() == {"result": "ok"}
     assert task.ran == 1
@@ -90,7 +90,7 @@ def test_run_task_async_endpoint(monkeypatch, tmp_path):
     async_task = AsyncTask()
     sched.register_task(name_or_task="async", task_or_expr=async_task)
     client = TestClient(app)
-    resp = client.post("/tasks/async/run-async")
+    resp = client.post("/tasks/async/run-async", headers={"X-User-ID": "alice"})
     assert resp.status_code == 200
     assert resp.json() == {"result": "async"}
 
@@ -119,7 +119,10 @@ def test_run_task_group_header(monkeypatch, tmp_path):
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
     monkeypatch.setattr(sched, "run_task", fake_run)
     client = TestClient(app)
-    client.post("/tasks/dummy/run", headers={"X-Group-ID": "team"})
+    client.post(
+        "/tasks/dummy/run",
+        headers={"X-User-ID": "alice", "X-Group-ID": "team"},
+    )
     assert called["gid"] == "team"
 
 
@@ -195,7 +198,7 @@ def test_schedule_task_group_header(monkeypatch, tmp_path):
     client.post(
         "/tasks/dummy/schedule",
         params={"expression": "*/5 * * * *"},
-        headers={"X-Group-ID": "team"},
+        headers={"X-User-ID": "alice", "X-Group-ID": "team"},
     )
     assert called["gid"] == "team"
 
@@ -203,7 +206,11 @@ def test_schedule_task_group_header(monkeypatch, tmp_path):
 def test_schedule_task(monkeypatch, tmp_path):
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
-    resp = client.post("/tasks/dummy/schedule", params={"expression": "*/5 * * * *"})
+    resp = client.post(
+        "/tasks/dummy/schedule",
+        params={"expression": "*/5 * * * *"},
+        headers={"X-User-ID": "alice"},
+    )
     assert resp.status_code == 200
     job = sched.scheduler.get_job("DummyTask")
     assert job is not None
@@ -225,7 +232,10 @@ def test_register_task(monkeypatch, tmp_path):
     assert "dynamic" in [name for name, _ in sched.list_tasks()]
     data = yaml.safe_load(open(tmp_path / "tasks.yml").read())
     assert "tests.test_api:DynamicTask" in data
-    run = client.post("/tasks/dynamic/run")
+    run = client.post(
+        "/tasks/dynamic/run",
+        headers={"X-User-ID": "alice"},
+    )
     assert run.status_code == 200
     assert run.json()["result"] == "dyn"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_manual_trigger_cli(monkeypatch):
     monkeypatch.setattr(ume, "emit_task_run", lambda run, user_id=None: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["trigger", "manual_demo"])
+    result = runner.invoke(app, ["trigger", "manual_demo", "--user-id", "alice"])
     assert result.exit_code == 0
 
 
@@ -64,7 +64,7 @@ def test_run_command_temporal(monkeypatch):
     monkeypatch.setattr(backend, "run_workflow_sync", fake_run)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["run", "dummy", "--temporal"])
+    result = runner.invoke(app, ["run", "dummy", "--temporal", "--user-id", "alice"])
     assert result.exit_code == 0
     assert called["workflow"] == "DummyTask"
 
@@ -111,11 +111,14 @@ def test_cli_schedule_creates_entry(monkeypatch, tmp_path):
     sched.register_task(name_or_task="example", task_or_expr=ExampleTask())
 
     runner = CliRunner()
-    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+    result = runner.invoke(
+        app, ["schedule", "example", "0 12 * * *", "--user-id", "alice"]
+    )
 
     assert result.exit_code == 0
     data = yaml.safe_load((tmp_path / "sched.yml").read_text())
-    assert data["ExampleTask"] == "0 12 * * *"
+    assert data["ExampleTask"]["expr"] == "0 12 * * *"
+    assert data["ExampleTask"]["user_id"] == "alice"
 
 
 def test_cli_schedule_user_id(monkeypatch, tmp_path):
@@ -146,7 +149,9 @@ def test_cli_schedule_unknown_task(monkeypatch):
     monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["schedule", "missing", "* * * * *"])
+    result = runner.invoke(
+        app, ["schedule", "missing", "* * * * *", "--user-id", "alice"]
+    )
 
     assert result.exit_code == 1
 
@@ -160,7 +165,9 @@ def test_cli_schedule_requires_cron_scheduler(monkeypatch):
     monkeypatch.setattr("task_cascadence.cli.get_default_scheduler", lambda: sched)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+    result = runner.invoke(
+        app, ["schedule", "example", "0 12 * * *", "--user-id", "alice"]
+    )
 
     assert result.exit_code == 1
     assert "scheduler lacks cron capabilities" in result.output
@@ -173,7 +180,9 @@ def test_cli_schedule_env_base(monkeypatch):
     importlib.reload(task_cascadence)
     task_cascadence.initialize()
     runner = CliRunner()
-    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+    result = runner.invoke(
+        app, ["schedule", "example", "0 12 * * *", "--user-id", "alice"]
+    )
     assert result.exit_code == 1
     assert "scheduler lacks cron capabilities" in result.output
 
@@ -425,7 +434,7 @@ def test_cli_run_pipeline_task(monkeypatch):
     monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["run", "pipe_demo"])
+    result = runner.invoke(app, ["run", "pipe_demo", "--user-id", "alice"])
 
     assert result.exit_code == 0
     assert steps == ["intake", "run"]
@@ -468,7 +477,9 @@ def test_cli_unschedule(monkeypatch, tmp_path):
     sched.register_task(name_or_task="example", task_or_expr=ExampleTask())
 
     runner = CliRunner()
-    result = runner.invoke(app, ["schedule", "example", "0 12 * * *"])
+    result = runner.invoke(
+        app, ["schedule", "example", "0 12 * * *", "--user-id", "alice"]
+    )
     assert result.exit_code == 0
 
     result = runner.invoke(app, ["unschedule", "example"])
@@ -511,7 +522,9 @@ def test_cli_run_async(monkeypatch):
     monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["run-async", "async_demo"])
+    result = runner.invoke(
+        app, ["run-async", "async_demo", "--user-id", "alice"]
+    )
 
     assert result.exit_code == 0
     assert steps == ["run"]
@@ -573,7 +586,7 @@ def test_cli_disable_prevents_run(monkeypatch):
     assert result.exit_code == 0
     assert "demo disabled" in result.output
 
-    result = runner.invoke(app, ["run", "demo"])
+    result = runner.invoke(app, ["run", "demo", "--user-id", "alice"])
     assert result.exit_code != 0
     assert "disabled" in (result.stderr or result.output)
 


### PR DESCRIPTION
## Summary
- enforce `X-User-ID` header for API task and suggestion endpoints
- make CLI `run`, `run-async`, `trigger`, and `schedule` commands require `--user-id`
- update tests to include user identifiers

## Testing
- `ruff check task_cascadence/api/__init__.py task_cascadence/cli/__init__.py tests/test_api.py tests/test_cli.py`
- `pytest tests/test_api.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68964d626cfc83268a7fba236bfcaaa0