### PR TITLE
feat: support calendar event scheduling from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ This endpoint returns the chronological audit trail for ``MyTask``.
 
 ``CronScheduler`` persists recurrence rules in ``schedules.yml``.  The file is
 created next to the running application unless ``storage_path`` is overridden
-and maps task names to cron expressions and optional context:
+and maps task names to cron expressions and optional context.  Schedules may be
+specified directly with an ``expr`` field or by referencing a UME calendar
+event:
 
 ```yaml
 ExampleTask:
@@ -314,6 +316,16 @@ ExampleTask:
   group_id: ops
   recurrence:
     note: "every day at noon"
+
+Another form references an existing calendar event. The scheduler fetches the
+event's recurrence rule and applies it, optionally polling for changes:
+
+```yaml
+ExampleTask:
+  calendar_event:
+    node: "evt123"
+    poll: 3600  # refresh every hour
+```
 ```
 
 The scheduler reloads this file on startup and recreates any jobs whose task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,57 @@
 import pytest
+import importlib.util
+import sys
+from types import ModuleType
+from pathlib import Path
 
-import task_cascadence.scheduler as scheduler_module
+
+# Load scheduler module directly without importing full package dependencies
+pkg = ModuleType("task_cascadence")
+sys.modules.setdefault("task_cascadence", pkg)
+temporal_mod = ModuleType("task_cascadence.temporal")
+
+
+class TemporalBackend:  # minimal stub for tests
+    pass
+
+
+temporal_mod.TemporalBackend = TemporalBackend
+sys.modules["task_cascadence.temporal"] = temporal_mod
+pkg.temporal = temporal_mod
+
+metrics_mod = ModuleType("task_cascadence.metrics")
+
+
+def track_task(*args, **kwargs):
+    def deco(fn):
+        return fn
+
+    return deco
+
+
+metrics_mod.track_task = track_task
+sys.modules["task_cascadence.metrics"] = metrics_mod
+pkg.metrics = metrics_mod
+
+http_spec = importlib.util.spec_from_file_location(
+    "task_cascadence.http_utils",
+    Path(__file__).resolve().parents[1] / "task_cascadence" / "http_utils.py",
+)
+http_utils = importlib.util.module_from_spec(http_spec)
+sys.modules["task_cascadence.http_utils"] = http_utils
+http_spec.loader.exec_module(http_utils)  # type: ignore[union-attr]
+pkg.http_utils = http_utils
+spec = importlib.util.spec_from_file_location(
+    "task_cascadence.scheduler",
+    Path(__file__).resolve().parents[1]
+    / "task_cascadence"
+    / "scheduler"
+    / "__init__.py",
+)
+scheduler_module = importlib.util.module_from_spec(spec)
+sys.modules["task_cascadence.scheduler"] = scheduler_module
+spec.loader.exec_module(scheduler_module)  # type: ignore[union-attr]
+pkg.scheduler = scheduler_module
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -1,4 +1,5 @@
 import yaml
+from apscheduler.triggers.cron import CronTrigger
 from task_cascadence.scheduler import CronScheduler
 
 
@@ -44,3 +45,45 @@ def test_schedule_from_calendar_event(tmp_path):
     assert persisted["DummyTask"]["user_id"] == "alice"
     assert persisted["DummyTask"]["group_id"] == "engineering"
     assert persisted["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
+
+
+def test_yaml_calendar_event_daily(tmp_path, monkeypatch):
+    data = {"DummyTask": {"calendar_event": "evt1"}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+
+    def fake_fetch(self, node):
+        assert node == "evt1"
+        return {"recurrence": {"cron": "0 9 * * *"}}
+
+    monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)
+    sched.load_yaml(cfg, {"DummyTask": task})
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+    expected = CronTrigger.from_crontab("0 9 * * *", timezone="UTC")
+    assert str(job.trigger) == str(expected)
+    entry = sched.schedules["DummyTask"]
+    assert entry["calendar_event"] == {"node": "evt1"}
+
+
+def test_yaml_calendar_event_weekly(tmp_path, monkeypatch):
+    data = {"DummyTask": {"calendar_event": "evt2"}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+
+    def fake_fetch(self, node):
+        assert node == "evt2"
+        return {"recurrence": {"cron": "30 10 * * 1"}}
+
+    monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)
+    sched.load_yaml(cfg, {"DummyTask": task})
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+    expected = CronTrigger.from_crontab("30 10 * * 1", timezone="UTC")
+    assert str(job.trigger) == str(expected)
+    entry = sched.schedules["DummyTask"]
+    assert entry["calendar_event"] == {"node": "evt2"}


### PR DESCRIPTION
## Summary
- allow `CronScheduler` to fetch UME calendar events and poll for recurrence updates
- support `calendar_event` entries in YAML schedule files
- document new YAML schema and add tests for daily and weekly recurrences

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/test_yaml_schedule.py`
- `pytest tests/test_yaml_schedule.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689654b7eb548326920831b9544f41f5