### PR TITLE
Add financial decision support failure handling tests

### DIFF
--- a/task_cascadence/workflows/financial_decision_support.py
+++ b/task_cascadence/workflows/financial_decision_support.py
@@ -17,99 +17,114 @@ def financial_decision_support(
     engine_base: str = "http://finance-engine",
 ) -> Dict[str, Any]:
     """Aggregate financial data, run a debt simulation, and persist results."""
-
     group_id = payload.get("group_id")
     time_horizon = payload.get("time_horizon")
 
-    url = f"{ume_base.rstrip('/')}/v1/nodes"
-    params: Dict[str, Any] = {
-        "types": "FinancialAccount,FinancialGoal,DecisionAnalysis",
-        "user_id": user_id,
-    }
-    if group_id is not None:
-        params["group_id"] = group_id
-    if time_horizon is not None:
-        params["time_horizon"] = time_horizon
-    resp = request_with_retry("GET", url, params=params, timeout=5)
-    data = resp.json()
-    nodes: List[Dict[str, Any]] = data.get("nodes", [])
+    required_fields = {"budget", "max_options"}
+    missing = [f for f in required_fields if f not in payload]
+    if missing:
+        emit_stage_update_event(
+            "finance.decision.result", "error", user_id=user_id, group_id=group_id
+        )
+        raise ValueError(f"Missing required fields: {', '.join(missing)}")
 
-    accounts = [n for n in nodes if n.get("type") == "FinancialAccount"]
-    goals = [n for n in nodes if n.get("type") == "FinancialGoal"]
-    analyses = [n for n in nodes if n.get("type") == "DecisionAnalysis"]
-
-    total_balance = sum(a.get("balance", 0) for a in accounts)
-
-    engine_payload = {"balance": total_balance, "goals": goals, "analyses": analyses}
-
-    if "budget" in payload:
-        engine_payload["budget"] = payload["budget"]
-    if "max_options" in payload:
-        engine_payload["max_options"] = payload["max_options"]
-    eng_resp = request_with_retry(
-        "POST", f"{engine_base.rstrip('/')}/v1/simulations/debt", json=engine_payload, timeout=5
-    )
-    eng_result = eng_resp.json()
-
-    analysis_id = eng_result.get("id", "analysis")
-    actions: List[Dict[str, Any]] = eng_result.get("actions", [])
-    analysis_node: Dict[str, Any] = {
-        "id": analysis_id,
-        "type": "DecisionAnalysis",
-        "metrics": {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)},
-        "user_id": user_id,
-    }
-    if group_id is not None:
-        analysis_node["group_id"] = group_id
-    if time_horizon is not None:
-        analysis_node["metadata"] = {"time_horizon": time_horizon}
-    nodes_to_persist = [analysis_node]
-    edges = []
-
-    for act in actions:
-        act_id = act.get("id")
-        node = {
-            "id": act_id,
-            "type": "ProposedAction",
-            "metrics": {"cost_of_deviation": act.get("cost_of_deviation")},
+    try:
+        url = f"{ume_base.rstrip('/')}/v1/nodes"
+        params: Dict[str, Any] = {
+            "types": "FinancialAccount,FinancialGoal,DecisionAnalysis",
             "user_id": user_id,
         }
         if group_id is not None:
-            node["group_id"] = group_id
-        nodes_to_persist.append(node)
-        edge = {"src": analysis_id, "dst": act_id, "type": "CONSIDERS", "user_id": user_id}
+            params["group_id"] = group_id
+        if time_horizon is not None:
+            params["time_horizon"] = time_horizon
+        resp = request_with_retry("GET", url, params=params, timeout=5)
+        data = resp.json()
+        nodes: List[Dict[str, Any]] = data.get("nodes", [])
+
+        accounts = [n for n in nodes if n.get("type") == "FinancialAccount"]
+        goals = [n for n in nodes if n.get("type") == "FinancialGoal"]
+        analyses = [n for n in nodes if n.get("type") == "DecisionAnalysis"]
+
+        total_balance = sum(a.get("balance", 0) for a in accounts)
+
+        engine_payload = {"balance": total_balance, "goals": goals, "analyses": analyses}
+
+        if "budget" in payload:
+            engine_payload["budget"] = payload["budget"]
+        if "max_options" in payload:
+            engine_payload["max_options"] = payload["max_options"]
+        eng_resp = request_with_retry(
+            "POST", f"{engine_base.rstrip('/')}/v1/simulations/debt", json=engine_payload, timeout=5
+        )
+        eng_result = eng_resp.json()
+
+        analysis_id = eng_result.get("id", "analysis")
+        actions: List[Dict[str, Any]] = eng_result.get("actions", [])
+        analysis_node: Dict[str, Any] = {
+            "id": analysis_id,
+            "type": "DecisionAnalysis",
+            "metrics": {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)},
+            "user_id": user_id,
+        }
         if group_id is not None:
-            edge["group_id"] = group_id
-        edges.append(edge)
-        for account in accounts:
-            owned_edge = {
-                "src": act_id,
-                "dst": account.get("id"),
-                "type": "OWNED_BY",
+            analysis_node["group_id"] = group_id
+        if time_horizon is not None:
+            analysis_node["metadata"] = {"time_horizon": time_horizon}
+        nodes_to_persist = [analysis_node]
+        edges = []
+
+        for act in actions:
+            act_id = act.get("id")
+            node = {
+                "id": act_id,
+                "type": "ProposedAction",
+                "metrics": {"cost_of_deviation": act.get("cost_of_deviation")},
                 "user_id": user_id,
             }
             if group_id is not None:
-                owned_edge["group_id"] = group_id
-            edges.append(owned_edge)
+                node["group_id"] = group_id
+            nodes_to_persist.append(node)
+            edge = {"src": analysis_id, "dst": act_id, "type": "CONSIDERS", "user_id": user_id}
+            if group_id is not None:
+                edge["group_id"] = group_id
+            edges.append(edge)
+            for account in accounts:
+                owned_edge = {
+                    "src": act_id,
+                    "dst": account.get("id"),
+                    "type": "OWNED_BY",
+                    "user_id": user_id,
+                }
+                if group_id is not None:
+                    owned_edge["group_id"] = group_id
+                edges.append(owned_edge)
 
-    request_with_retry("POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5)
-
-    summary = {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)}
-    context = {"analysis": analysis_id, "summary": summary}
-
-    dispatch("finance.decision.result", context, user_id=user_id, group_id=group_id)
-    if payload.get("explain"):
-        dispatch(
-            "finance.explain.request",
-            {**context, "actions": actions},
-
-            user_id=user_id,
-            group_id=group_id,
+        request_with_retry(
+            "POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5
         )
 
-    emit_stage_update_event(
-        "finance.decision.result", "completed", user_id=user_id, group_id=group_id
-    )
+        summary = {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)}
+        context = {"analysis": analysis_id, "summary": summary}
 
-    return {**context, "actions": actions}
+        dispatch("finance.decision.result", context, user_id=user_id, group_id=group_id)
+        if payload.get("explain"):
+            dispatch(
+                "finance.explain.request",
+                {**context, "actions": actions},
+
+                user_id=user_id,
+                group_id=group_id,
+            )
+
+        emit_stage_update_event(
+            "finance.decision.result", "completed", user_id=user_id, group_id=group_id
+        )
+
+        return {**context, "actions": actions}
+    except Exception:
+        emit_stage_update_event(
+            "finance.decision.result", "error", user_id=user_id, group_id=group_id
+        )
+        raise
 


### PR DESCRIPTION
## Summary
- validate required fields and emit error stage when missing
- emit error stage on exceptions in financial decision support workflow
- test UME HTTP errors, engine failure, and missing payload fields

## Testing
- `ruff check task_cascadence/workflows/financial_decision_support.py tests/test_financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py`


------
https://chatgpt.com/codex/tasks/task_e_6896ba0d20f083269e782bbe7503bf45