### PR TITLE
Add test for calendar event recurrence scheduling

### DIFF
--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -87,3 +87,116 @@ def test_yaml_calendar_event_weekly(tmp_path, monkeypatch):
     assert str(job.trigger) == str(expected)
     entry = sched.schedules["DummyTask"]
     assert entry["calendar_event"] == {"node": "evt2"}
+
+
+def test_yaml_calendar_event_multiple_recurrences(tmp_path, monkeypatch):
+    data = {
+        "DummyTask": {
+            "calendar_event": "evt3",
+            "user_id": "alice",
+            "group_id": "engineering",
+        }
+    }
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+
+    def fake_fetch(self, node):
+        assert node == "evt3"
+        return {"recurrence": {"cron": "*/2 * * * *"}}
+
+    monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)
+
+    captured: list[tuple[str | None, str | None, str | None]] = []
+
+    import sys
+    import types
+
+    ume_mod = types.ModuleType("task_cascadence.ume")
+    models_mod = types.ModuleType("task_cascadence.ume.models")
+
+    class TaskSpec:
+        def __init__(self, id: str, name: str):
+            self.id = id
+            self.name = name
+
+    class TaskRun:
+        def __init__(self, spec, run_id, status, started_at, finished_at):
+            self.spec = spec
+            self.run_id = run_id
+            self.status = status
+            self.started_at = started_at
+            self.finished_at = finished_at
+            self.user_hash = None
+
+    models_mod.TaskSpec = TaskSpec
+    models_mod.TaskRun = TaskRun
+    sys.modules["task_cascadence.ume.models"] = models_mod
+    ume_mod.models = models_mod
+
+    orch_mod = types.ModuleType("task_cascadence.orchestrator")
+
+    class TaskPipeline:
+        def __init__(self, task):
+            self._task = task
+
+        def run(self, user_id=None, group_id=None):  # pragma: no cover - simple stub
+            return self._task.run()
+
+    orch_mod.TaskPipeline = TaskPipeline
+    sys.modules["task_cascadence.orchestrator"] = orch_mod
+
+    pr_mod = types.ModuleType("task_cascadence.pipeline_registry")
+
+    def add_pipeline(name, pipeline):  # pragma: no cover - stub
+        pass
+
+    def remove_pipeline(name):  # pragma: no cover - stub
+        pass
+
+    pr_mod.add_pipeline = add_pipeline
+    pr_mod.remove_pipeline = remove_pipeline
+    sys.modules["task_cascadence.pipeline_registry"] = pr_mod
+
+    def fake_emit(run, user_id=None, group_id=None):
+        captured.append((run.user_hash, user_id, group_id))
+
+    ume_mod.emit_task_run = fake_emit
+    sys.modules["task_cascadence.ume"] = ume_mod
+
+    sched.load_yaml(cfg, {"DummyTask": task})
+    job = sched.scheduler.get_job("DummyTask")
+    assert job is not None
+
+    import datetime as dt
+
+    start = dt.datetime(2024, 1, 1, 9, 0, tzinfo=job.trigger.timezone)
+    first = job.trigger.get_next_fire_time(None, start)
+    second = job.trigger.get_next_fire_time(first, first)
+    assert (second - first) == dt.timedelta(minutes=2)
+
+    times = iter(
+        [
+            first,
+            first + dt.timedelta(seconds=1),
+            second,
+            second + dt.timedelta(seconds=1),
+        ]
+    )
+
+    class FrozenDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):  # pragma: no cover - simple wrapper
+            return next(times)
+
+    monkeypatch.setattr(dt, "datetime", FrozenDatetime)
+
+    job.func()
+    job.func()
+
+    assert task.count == 2
+    assert captured == [
+        (captured[0][0], "alice", "engineering"),
+        (captured[1][0], "alice", "engineering"),
+    ]


### PR DESCRIPTION
## Summary
- add regression test covering YAML schedule calendar events
- verify user and group identifiers propagate through scheduled runs
- simulate time to ensure calendar-based tasks fire multiple times

## Testing
- `ruff check tests/test_yaml_schedule.py`
- `pytest tests/test_yaml_schedule.py::test_yaml_calendar_event_multiple_recurrences -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ba0dc10c8326b39ff3befb3d88c4