### PR TITLE
Validate group_id in financial decision support workflow

### DIFF
--- a/task_cascadence/workflows/financial_decision_support.py
+++ b/task_cascadence/workflows/financial_decision_support.py
@@ -17,7 +17,12 @@ def financial_decision_support(
     engine_base: str = "http://finance-engine",
 ) -> Dict[str, Any]:
     """Aggregate financial data, run a debt simulation, and persist results."""
-    group_id = payload.get("group_id")
+    payload_group_id = payload.get("group_id")
+    if payload_group_id is not None and payload_group_id != group_id:
+        emit_stage_update_event(
+            "finance.decision.result", "error", user_id=user_id, group_id=group_id
+        )
+        raise ValueError("Payload group_id does not match caller group_id")
     time_horizon = payload.get("time_horizon")
 
     required_fields = {"budget", "max_options"}

--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -89,9 +89,9 @@ def test_financial_decision_support(monkeypatch):
 
     result = dispatch(
         "finance.decision.request",
-        {"explain": True, "group_id": "g1", "budget": 100, "max_options": 3},
+        {"explain": True, "budget": 100, "max_options": 3},
         user_id="alice",
-
+        group_id="g1",
     )
 
     # ensure UME query
@@ -136,6 +136,23 @@ def test_financial_decision_support(monkeypatch):
 
     assert result["analysis"] == "da1"
     assert result["summary"]["cost_of_deviation"] == 50
+
+
+def test_financial_decision_support_group_id_mismatch(monkeypatch):
+    def fake_request(*a, **k):
+        raise AssertionError("request should not be called")
+
+    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
+    monkeypatch.setattr(fds, "dispatch", lambda *a, **k: None)
+
+    with pytest.raises(ValueError):
+        dispatch(
+            "finance.decision.request",
+            {"group_id": "g2", "budget": 0, "max_options": 0},
+            user_id="alice",
+            group_id="g1",
+        )
 
 
 def test_financial_decision_support_time_horizon(monkeypatch):


### PR DESCRIPTION
## Summary
- validate group_id in financial decision support workflow
- adjust tests to pass group_id parameter and verify mismatched group_id detection

## Testing
- `ruff check task_cascadence/workflows/financial_decision_support.py tests/test_financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bc131ca083269df0ea47e015c1be