### PR TITLE
Propagate user and group context to tasks

### DIFF
--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -479,6 +479,8 @@ class TaskPipeline:
 
     # ------------------------------------------------------------------
     def run(self, *, user_id: str, group_id: str | None = None) -> Any:
+        self.task.user_id = user_id
+        self.task.group_id = group_id
         loop_running = True
         try:
             asyncio.get_running_loop()
@@ -545,7 +547,8 @@ class TaskPipeline:
         self, *, user_id: str, group_id: str | None = None
     ) -> Any:
         """Asynchronously execute this pipeline."""
-
+        self.task.user_id = user_id
+        self.task.group_id = group_id
         self.intake(user_id=user_id, group_id=group_id)
         await self._wait_if_paused_async()
 

--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -24,6 +24,8 @@ class BaseTask:
     """Base class for all tasks."""
 
     name: str = "base"
+    user_id: str | None = None
+    group_id: str | None = None
 
     def run(self):  # pragma: no cover - trivial demo function
         """Run the task."""

--- a/tests/test_task_context.py
+++ b/tests/test_task_context.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+import pytest
+
+pkg = sys.modules.setdefault("task_cascadence", ModuleType("task_cascadence"))
+pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "task_cascadence")]
+
+from task_cascadence.orchestrator import TaskPipeline  # noqa: E402
+from task_cascadence.plugins import BaseTask  # noqa: E402
+
+
+class ContextTask(BaseTask):
+    name = "context"
+
+    def run(self):
+        self.seen_user_id = self.user_id
+        self.seen_group_id = self.group_id
+        return "ok"
+
+
+def _patch_events(monkeypatch):
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_stage_update_event", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_audit_log", lambda *a, **k: None)
+
+
+def test_task_pipeline_context(monkeypatch):
+    _patch_events(monkeypatch)
+    task = ContextTask()
+    pipeline = TaskPipeline(task)
+    pipeline.run(user_id="alice", group_id="team1")
+    assert task.seen_user_id == "alice"
+    assert task.seen_group_id == "team1"
+    assert task.user_id == "alice"
+    assert task.group_id == "team1"
+
+
+@pytest.mark.asyncio
+async def test_task_pipeline_context_async(monkeypatch):
+    _patch_events(monkeypatch)
+    task = ContextTask()
+    pipeline = TaskPipeline(task)
+    await pipeline.run_async(user_id="bob", group_id="team2")
+    assert task.seen_user_id == "bob"
+    assert task.seen_group_id == "team2"
+    assert task.user_id == "bob"
+    assert task.group_id == "team2"


### PR DESCRIPTION
## Summary
- add `user_id` and `group_id` fields to `BaseTask`
- set task context in `TaskPipeline.run` and `run_async`
- regression test verifying tasks receive user and group ids

## Testing
- `ruff check task_cascadence/plugins/__init__.py task_cascadence/orchestrator.py tests/test_task_context.py`
- `pytest tests/test_task_context.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897fcc383088326b4f758ee3f1ec4da