### PR TITLE
Add audit logging and failure context for financial decision workflow

### DIFF
--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -44,6 +44,8 @@ def test_financial_decision_support(monkeypatch):
             assert len(kwargs["json"]["analyses"]) == 1
             assert kwargs["json"]["budget"] == 100
             assert kwargs["json"]["max_options"] == 3
+            assert kwargs["json"]["user_id"] == "alice"
+            assert kwargs["json"]["group_id"] == "g1"
             return DummyResponse(
                 {
                     "id": "da1",
@@ -66,9 +68,15 @@ def test_financial_decision_support(monkeypatch):
     def fake_dispatch(event, payload, user_id, group_id=None):
         dispatched.append((event, payload, user_id, group_id))
 
+    audit_logs = []
+
+    def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
+        audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
+
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
 
     result = dispatch(
         "finance.decision.request",
@@ -120,6 +128,9 @@ def test_financial_decision_support(monkeypatch):
     assert result["analysis"] == "da1"
     assert result["summary"]["cost_of_deviation"] == 50
 
+    assert ("finance.decision", "workflow", "started", None, None, "alice", "g1") in audit_logs
+    assert ("finance.decision", "workflow", "completed", None, None, "alice", "g1") in audit_logs
+
 
 def test_financial_decision_support_group_id_mismatch(monkeypatch):
     def fake_request(*a, **k):
@@ -128,6 +139,7 @@ def test_financial_decision_support_group_id_mismatch(monkeypatch):
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
     monkeypatch.setattr(fds, "dispatch", lambda *a, **k: None)
+    monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
 
     with pytest.raises(ValueError):
         dispatch(
@@ -153,6 +165,7 @@ def test_financial_decision_support_time_horizon(monkeypatch):
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
     monkeypatch.setattr(fds, "dispatch", lambda *a, **k: None)
+    monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
 
     dispatch(
         "finance.decision.request",
@@ -188,6 +201,7 @@ def test_financial_decision_support_ume_error(monkeypatch):
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
 
     with pytest.raises(requests.HTTPError):
         dispatch(
@@ -222,9 +236,15 @@ def test_financial_decision_support_engine_failure(monkeypatch):
     def fake_dispatch(event, payload, user_id, group_id=None):
         dispatched.append(event)
 
+    audit_logs: list[tuple[str, str, str, str, str | None, str | None, str | None]] = []
+
+    def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
+        audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
+
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
 
     with pytest.raises(requests.HTTPError):
         dispatch(
@@ -236,6 +256,54 @@ def test_financial_decision_support_engine_failure(monkeypatch):
     assert len(calls) == 2
     assert emitted == [("finance.decision.result", "error", "alice", None)]
     assert "finance.decision.result" not in dispatched
+    assert any(a[1] == "engine" and a[2] == "error" and "boom" in a[3] and "budget" in a[4] for a in audit_logs)
+    assert any(a[1] == "workflow" and a[2] == "error" for a in audit_logs)
+
+
+def test_financial_decision_support_persistence_failure(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, timeout, **kwargs):
+        calls.append((method, url, kwargs))
+        if method == "GET":
+            return DummyResponse({"nodes": []})
+        elif url.endswith("/v1/simulations/debt"):
+            return DummyResponse({"id": "da1", "actions": []})
+        else:
+            raise requests.HTTPError("boom")
+
+    emitted = []
+
+    def fake_emit(name, stage, user_id=None, group_id=None, **_):
+        emitted.append((name, stage, user_id, group_id))
+
+    dispatched = []
+
+    def fake_dispatch(event, payload, user_id, group_id=None):
+        dispatched.append(event)
+
+    audit_logs = []
+
+    def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
+        audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
+
+    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
+    monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
+
+    with pytest.raises(requests.HTTPError):
+        dispatch(
+            "finance.decision.request",
+            {"budget": 100, "max_options": 3},
+            user_id="alice",
+        )
+
+    assert len(calls) == 3
+    assert emitted == [("finance.decision.result", "error", "alice", None)]
+    assert "finance.decision.result" not in dispatched
+    assert any(a[1] == "persistence" and a[2] == "error" and "boom" in a[3] and "nodes" in a[4] for a in audit_logs)
+    assert any(a[1] == "workflow" and a[2] == "error" for a in audit_logs)
 
 
 def test_financial_decision_support_missing_fields(monkeypatch):
@@ -258,6 +326,7 @@ def test_financial_decision_support_missing_fields(monkeypatch):
     monkeypatch.setattr(fds, "request_with_retry", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
 
     with pytest.raises(ValueError):
         dispatch("finance.decision.request", {}, user_id="alice")


### PR DESCRIPTION
## Summary
- log audit events at workflow start, completion, and error
- include user and optional group identifiers in debt simulation payload
- capture engine and persistence failure details with audit logs and add tests

## Testing
- `ruff check task_cascadence/workflows/financial_decision_support.py tests/test_financial_decision_support.py`
- `mypy task_cascadence/workflows/financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py`

------
https://chatgpt.com/codex/tasks/task_e_689bcb9f23548326bbfa43fff4e4febd