### PR TITLE
Refactor async execution and audit logging

### DIFF
--- a/d0tTino_cli.py
+++ b/d0tTino_cli.py
@@ -10,8 +10,12 @@ app = typer.Typer(help="Interact with TaskCascadence intent API")
 
 def _post(base_url: str, payload: dict) -> dict:
     url = f"{base_url.rstrip('/')}/intent"
-    response = requests.post(url, json=payload, timeout=30)
-    response.raise_for_status()
+    try:
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        typer.echo(f"error contacting {url}: {exc}", err=True)
+        raise
     return response.json()
 
 

--- a/task_cascadence/async_utils.py
+++ b/task_cascadence/async_utils.py
@@ -1,0 +1,28 @@
+"""Async helpers for running coroutines in a loop-aware manner."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine
+
+
+def run_coroutine(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run ``coro`` using the current event loop if available.
+
+    If no event loop is running, a temporary loop is created and closed after
+    execution. When a loop is running, the coroutine is scheduled using
+    :func:`asyncio.create_task` and the resulting task is returned for the
+    caller to await.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(coro)
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+    else:
+        return loop.create_task(coro)

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -130,14 +130,14 @@ def run_task_async(
 
     from ..ume import emit_stage_update_event
     import inspect
-    import asyncio
     from typing import Coroutine, Any, cast
+    from ..async_utils import run_coroutine
 
     try:
         emit_stage_update_event(name, "start", user_id=user_id)
         result = get_default_scheduler().run_task(name, use_temporal=temporal, user_id=user_id)
         if inspect.isawaitable(result):
-            result = asyncio.run(cast(Coroutine[Any, Any, Any], result))
+            result = run_coroutine(cast(Coroutine[Any, Any, Any], result))
         emit_stage_update_event(name, "finish", user_id=user_id)
     except Exception as exc:  # pragma: no cover - simple error propagation
         emit_stage_update_event(name, "error", user_id=user_id)

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -24,6 +24,7 @@ from .ume import (
 )
 from .ume.models import TaskRun, TaskSpec
 from . import research
+from .async_utils import run_coroutine
 import time
 
 
@@ -164,7 +165,7 @@ class TaskPipeline:
 
             if loop_running:
                 return _await_query()
-            return asyncio.run(_await_query())
+            return run_coroutine(_await_query())
 
         if loop_running:
 
@@ -251,7 +252,7 @@ class TaskPipeline:
                         try:
                             asyncio.get_running_loop()
                         except RuntimeError:
-                            check = asyncio.run(cast(Coroutine[Any, Any, Any], check))
+                            check = run_coroutine(cast(Coroutine[Any, Any, Any], check))
                         else:
                             _res = check
 
@@ -316,7 +317,7 @@ class TaskPipeline:
                 try:
                     asyncio.get_running_loop()
                 except RuntimeError:
-                    results = asyncio.run(_run_all())
+                    results = run_coroutine(_run_all())
                 else:
                     async def _await_all() -> list[Any]:
                         return await _run_all()
@@ -362,7 +363,7 @@ class TaskPipeline:
                 try:
                     asyncio.get_running_loop()
                 except RuntimeError:
-                    result = asyncio.run(_resolve_and_run())
+                    result = run_coroutine(_resolve_and_run())
                 else:
                     result = _resolve_and_run()
             else:
@@ -435,7 +436,9 @@ class TaskPipeline:
                     try:
                         asyncio.get_running_loop()
                     except RuntimeError:
-                        verify_result = asyncio.run(cast(Coroutine[Any, Any, Any], verify_result))
+                        verify_result = run_coroutine(
+                            cast(Coroutine[Any, Any, Any], verify_result)
+                        )
                     else:
                         _res = verify_result
 
@@ -626,7 +629,7 @@ class TaskPipeline:
             try:
                 asyncio.get_running_loop()
             except RuntimeError:
-                return asyncio.run(_async_call())
+                return run_coroutine(_async_call())
             return _async_call()
 
         if len(sig.parameters) > 0:

--- a/task_cascadence/plugins/d0tTino.py
+++ b/task_cascadence/plugins/d0tTino.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import subprocess
+import logging
 
 import requests
 
 from . import CronTask
+
+logger = logging.getLogger(__name__)
 
 
 class D0tTinoTask(CronTask):
@@ -20,8 +23,12 @@ class D0tTinoTask(CronTask):
     def _call(self, command: str) -> str:
         if self.use_api:
             url = f"{self.base_url}/{command}"
-            response = requests.post(url, json={"prompt": self.prompt}, timeout=30)
-            response.raise_for_status()
+            try:
+                response = requests.post(url, json={"prompt": self.prompt}, timeout=30)
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                logger.error("d0tTino API request failed: %s", exc)
+                raise
             return response.text.strip()
         result = subprocess.run(
             ["d0tTino", command, self.prompt],

--- a/task_cascadence/pointer_sync.py
+++ b/task_cascadence/pointer_sync.py
@@ -15,6 +15,7 @@ from .config import load_config
 from .pointer_store import PointerStore
 from .ume.models import PointerUpdate
 from .ume import emit_pointer_update
+from .async_utils import run_coroutine
 
 logger = logging.getLogger(__name__)
 
@@ -113,8 +114,7 @@ async def run_async() -> None:
 
 def run() -> None:
     """Synchronous wrapper for :func:`run_async`."""
-
-    asyncio.run(run_async())
+    run_coroutine(run_async())
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/task_cascadence/temporal.py
+++ b/task_cascadence/temporal.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional
-import asyncio
+from .async_utils import run_coroutine
 
 from temporalio.client import Client
 from temporalio.worker import Replayer
@@ -31,7 +31,7 @@ class TemporalBackend:
 
     def run_workflow_sync(self, workflow: str, *args: Any, **kwargs: Any) -> Any:
         """Synchronously execute ``workflow`` and return its result."""
-        return asyncio.run(self.run_workflow(workflow, *args, **kwargs))
+        return run_coroutine(self.run_workflow(workflow, *args, **kwargs))
 
     def replay(self, history_path: str) -> None:
         """Replay a workflow history from ``history_path`` for debugging."""

--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
@@ -9,6 +8,7 @@ from . import dispatch, subscribe
 from ..http_utils import request_with_retry
 from .. import research
 from ..ume import emit_stage_update_event, emit_task_note, emit_audit_log
+from ..async_utils import run_coroutine
 from ..ume.models import TaskNote
 
 
@@ -52,7 +52,7 @@ def create_calendar_event(
     travel_info: Dict[str, Any] | None = None
     if payload.get("location"):
         try:
-            travel_info = asyncio.run(
+            travel_info = run_coroutine(
                 research.async_gather(
                     f"travel time to {payload['location']}",
                     user_id=user_id,

--- a/task_cascadence/workflows/financial_decision_support.py
+++ b/task_cascadence/workflows/financial_decision_support.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from . import subscribe, dispatch
 from ..http_utils import request_with_retry
-from ..ume import emit_stage_update_event
+from ..ume import emit_stage_update_event, emit_audit_log
 
 
 @subscribe("finance.decision.request")
@@ -33,7 +33,10 @@ def financial_decision_support(
         )
         raise ValueError(f"Missing required fields: {', '.join(missing)}")
 
+    task_name = "finance.decision.workflow"
+    emit_audit_log(task_name, "workflow", "started", user_id=user_id, group_id=group_id)
     try:
+        emit_audit_log(task_name, "research", "started", user_id=user_id, group_id=group_id)
         url = f"{ume_base.rstrip('/')}/v1/nodes"
         params: Dict[str, Any] = {
             "types": "FinancialAccount,FinancialGoal,DecisionAnalysis",
@@ -43,8 +46,13 @@ def financial_decision_support(
             params["group_id"] = group_id
         if time_horizon is not None:
             params["time_horizon"] = time_horizon
-        resp = request_with_retry("GET", url, params=params, timeout=5)
-        data = resp.json()
+        try:
+            resp = request_with_retry("GET", url, params=params, timeout=5)
+            data = resp.json()
+        except Exception as exc:
+            emit_audit_log(task_name, "research", "error", reason=str(exc), user_id=user_id, group_id=group_id)
+            emit_audit_log(task_name, "workflow", "error", reason=str(exc), user_id=user_id, group_id=group_id)
+            raise
         nodes: List[Dict[str, Any]] = data.get("nodes", [])
 
         accounts = [n for n in nodes if n.get("type") == "FinancialAccount"]
@@ -59,10 +67,42 @@ def financial_decision_support(
             engine_payload["budget"] = payload["budget"]
         if "max_options" in payload:
             engine_payload["max_options"] = payload["max_options"]
-        eng_resp = request_with_retry(
-            "POST", f"{engine_base.rstrip('/')}/v1/simulations/debt", json=engine_payload, timeout=5
+        try:
+            eng_resp = request_with_retry(
+                "POST",
+                f"{engine_base.rstrip('/')}/v1/simulations/debt",
+                json=engine_payload,
+                timeout=5,
+            )
+            eng_result = eng_resp.json()
+        except Exception as exc:
+            emit_audit_log(
+                task_name,
+                "research",
+                "error",
+                reason=str(exc),
+                output=repr(engine_payload),
+                user_id=user_id,
+                group_id=group_id,
+            )
+            emit_audit_log(
+                task_name,
+                "workflow",
+                "error",
+                reason=str(exc),
+                output=repr(engine_payload),
+                user_id=user_id,
+                group_id=group_id,
+            )
+            raise
+        emit_audit_log(
+            task_name,
+            "research",
+            "success",
+            output=repr(eng_result),
+            user_id=user_id,
+            group_id=group_id,
         )
-        eng_result = eng_resp.json()
 
         analysis_id = eng_result.get("id", "analysis")
         actions: List[Dict[str, Any]] = eng_result.get("actions", [])
@@ -105,9 +145,33 @@ def financial_decision_support(
                     owned_edge["group_id"] = group_id
                 edges.append(owned_edge)
 
-        request_with_retry(
-            "POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5
-        )
+        emit_audit_log(task_name, "persist", "started", user_id=user_id, group_id=group_id)
+        try:
+            request_with_retry(
+                "POST", url, json={"nodes": nodes_to_persist, "edges": edges}, timeout=5
+            )
+        except Exception as exc:
+            payload_repr = repr({"nodes": nodes_to_persist, "edges": edges})
+            emit_audit_log(
+                task_name,
+                "persist",
+                "error",
+                reason=str(exc),
+                output=payload_repr,
+                user_id=user_id,
+                group_id=group_id,
+            )
+            emit_audit_log(
+                task_name,
+                "workflow",
+                "error",
+                reason=str(exc),
+                output=payload_repr,
+                user_id=user_id,
+                group_id=group_id,
+            )
+            raise
+        emit_audit_log(task_name, "persist", "success", user_id=user_id, group_id=group_id)
 
         summary = {"cost_of_deviation": eng_result.get("cost_of_deviation", 0)}
         context = {"analysis": analysis_id, "summary": summary}
@@ -126,10 +190,27 @@ def financial_decision_support(
             "finance.decision.result", "completed", user_id=user_id, group_id=group_id
         )
 
-        return {**context, "actions": actions}
-    except Exception:
+        result = {**context, "actions": actions}
+        emit_audit_log(
+            task_name,
+            "workflow",
+            "success",
+            output=repr(result),
+            user_id=user_id,
+            group_id=group_id,
+        )
+        return result
+    except Exception as exc:
         emit_stage_update_event(
             "finance.decision.result", "error", user_id=user_id, group_id=group_id
+        )
+        emit_audit_log(
+            task_name,
+            "workflow",
+            "error",
+            reason=str(exc),
+            user_id=user_id,
+            group_id=group_id,
         )
         raise
 


### PR DESCRIPTION
## Summary
- add loop-aware coroutine runner and replace asyncio.run usages
- log workflow start, research, and persistence around UME operations
- wrap HTTP requests in try/except to capture errors
- stabilize tests by stubbing transport-dependent UME hooks and fixing mypy typing

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/conftest.py`
- `pytest tests/test_ai_plan.py::test_ai_plan_module_used tests/test_async_verify.py::test_async_verify tests/test_cli.py::test_run_command_temporal tests/test_cli.py::test_cli_replay_history tests/test_metrics.py tests/test_mypy.py::test_mypy_runs`


------
https://chatgpt.com/codex/tasks/task_e_689bcb9de2c083268cd7dc059840b6de