### PR TITLE
Add tests for schedule error handling

### DIFF
--- a/tests/test_schedule_from_event.py
+++ b/tests/test_schedule_from_event.py
@@ -1,4 +1,5 @@
 import yaml
+import pytest
 from apscheduler.triggers.cron import CronTrigger
 from task_cascadence.scheduler import CronScheduler
 
@@ -35,3 +36,11 @@ def test_yaml_recurrence_loaded(tmp_path):
     task = DummyTask()
     sched.load_yaml(cfg, {"DummyTask": task})
     assert sched.schedules["DummyTask"]["recurrence"] == {"note": "every minute"}
+
+
+def test_schedule_from_event_missing_cron(tmp_path):
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    task = DummyTask()
+    event = {"recurrence": {}}
+    with pytest.raises(ValueError, match="event missing recurrence cron"):
+        sched.schedule_from_event(task, event)

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -1,4 +1,5 @@
 import yaml
+import pytest
 from apscheduler.triggers.cron import CronTrigger
 from task_cascadence.scheduler import CronScheduler
 
@@ -26,6 +27,14 @@ def test_load_yaml_schedule(tmp_path):
     job = sched.scheduler.get_job("DummyTask")
     assert job is not None
     assert sched.schedules["DummyTask"]["recurrence"] == {"note": "every minute"}
+
+
+def test_load_yaml_malformed(tmp_path):
+    cfg = tmp_path / "bad.yml"
+    cfg.write_text("DummyTask: [1, 2")
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    with pytest.raises(yaml.YAMLError):
+        sched.load_yaml(cfg, {"DummyTask": DummyTask()})
 
 
 def test_schedule_from_calendar_event(tmp_path):


### PR DESCRIPTION
## Summary
- add regression test for missing cron schedules
- ensure malformed YAML config surfaces errors

## Testing
- `ruff check tests/test_schedule_from_event.py tests/test_yaml_schedule.py`
- `pytest tests/test_schedule_from_event.py tests/test_yaml_schedule.py::test_load_yaml_schedule tests/test_yaml_schedule.py::test_load_yaml_malformed -q`


------
https://chatgpt.com/codex/tasks/task_e_689ccc213dd083268fc652bbcd7dc2ef