### PR TITLE
refactor: unify finance decision audit logs

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -65,10 +65,8 @@ def create_calendar_event(
                     f"travel time to {payload['location']}",
                     user_id=user_id,
                     group_id=group_id,
-
                 )
-            except Exception:
-                travel_info = None
+            )
         except Exception:
             travel_info = None
 


### PR DESCRIPTION
## Summary
- centralize `TASK_NAME` for finance decision workflow and remove duplicate start logging
- emit audit errors on group-id mismatch or missing required fields
- use shared task name for all workflow audit events
- fix calendar event travel info block to eliminate syntax error
- ensure coroutine helper executes safely when an event loop is already running
- align finance-decision audit stages with expectations (engine/persistence)

## Testing
- `ruff check task_cascadence/async_utils.py task_cascadence/workflows/financial_decision_support.py task_cascadence/workflows/calendar_event_creation.py`
- `mypy task_cascadence/async_utils.py task_cascadence/workflows/financial_decision_support.py task_cascadence/workflows/calendar_event_creation.py`
- `pytest tests/test_calendar_workflow.py::test_calendar_event_creation_in_event_loop`
- `pytest tests/test_financial_decision_support.py::test_financial_decision_support_engine_failure`
- `pytest tests/test_financial_decision_support.py::test_financial_decision_support_persistence_failure`
- `pytest` *(fails: no transport client configured and CLI pause/resume index errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf21456c83269274626a8d4528d0