### PR TITLE
Add import and research failure tests for calendar workflow

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -97,7 +97,6 @@ def create_calendar_event(
                     user_id=user_id,
                     group_id=group_id,
                 )
-            )
         except Exception:
             travel_info = None
 


### PR DESCRIPTION
## Summary
- add regression test ensuring calendar_event_creation module imports cleanly
- add test for research async_gather failures falling back to default behavior and auditing
- fix unmatched parenthesis in calendar_event_creation

## Testing
- `ruff check tests/test_calendar_workflow.py task_cascadence/workflows/calendar_event_creation.py`
- `pytest tests/test_calendar_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d386ab6d48326a62388aa28ce5006