### PR TITLE
test: cover financial decision audit logging

### DIFF
--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -158,6 +158,15 @@ def test_financial_decision_support_group_id_mismatch(monkeypatch):
             group_id="g1",
         )
 
+    assert (
+        "finance.decision",
+        "workflow",
+        "started",
+        None,
+        None,
+        "alice",
+        "g1",
+    ) in audit_logs
     assert any(
         a[1] == "workflow"
         and a[2] == "error"
@@ -401,6 +410,15 @@ def test_financial_decision_support_missing_fields(monkeypatch, payload, missing
     assert calls == []
     assert emitted == [("finance.decision.result", "error", "alice", None)]
     assert "finance.decision.result" not in dispatched
+    assert (
+        "finance.decision",
+        "workflow",
+        "started",
+        None,
+        None,
+        "alice",
+        None,
+    ) in audit_logs
     assert any(
         a[1] == "workflow"
         and a[2] == "error"


### PR DESCRIPTION
## Summary
- assert audit logs for group-id mismatches
- verify audit logging when required fields are missing

## Testing
- `ruff check tests/test_financial_decision_support.py`
- `pytest tests/test_financial_decision_support.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3be772a48326a6e7abf4ab705b45