### PR TITLE
Protect workflow registry with lock

### DIFF
--- a/task_cascadence/workflows/__init__.py
+++ b/task_cascadence/workflows/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from threading import RLock
+from threading import Lock
 from typing import Any, Callable, Dict
 
 _registry: Dict[str, Callable[..., Any]] = {}
-_registry_lock = RLock()
+_registry_lock = Lock()
 
 
 def subscribe(event: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:


### PR DESCRIPTION
## Summary
- use threading.Lock to guard workflow registry

## Testing
- `ruff check task_cascadence/workflows/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f40c4bc788326a031222549503c4b