### PR TITLE
Protect schedule loading with lock

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -250,7 +250,8 @@ class CronScheduler(BaseScheduler):
         self.scheduler = BackgroundScheduler(timezone=tz)
         self.storage_path = Path(storage_path)
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
-        self.schedules = self._load_schedules()
+        with self._schedules_lock:
+            self.schedules = self._load_schedules()
         self._restore_jobs(tasks or {})
 
     def _load_schedules(self):


### PR DESCRIPTION
## Summary
- guard CronScheduler schedule initialization with `_schedules_lock`

## Testing
- `ruff check task_cascadence/scheduler/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f40c57df4832691bea7c5d3e12934