### PR TITLE
Add header validation tests for task control endpoints

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -149,7 +149,11 @@ def schedule_task(
 
 
 @app.post("/tasks/{name}/disable")
-def disable_task(name: str):
+def disable_task(
+    name: str,
+    user_id: str = Depends(get_user_id),
+    group_id: str | None = Depends(get_group_id),
+):
     """Disable ``name``."""
     sched = get_default_scheduler()
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,12 +219,58 @@ def test_schedule_task(monkeypatch, tmp_path):
     assert job is not None
 
 
-def test_disable_task(monkeypatch, tmp_path):
+def test_disable_task_missing_headers(monkeypatch, tmp_path):
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
     resp = client.post("/tasks/dummy/disable")
+    assert resp.status_code == 400
+    assert sched._tasks["dummy"]["disabled"] is False
+
+
+def test_disable_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    headers = {"X-User-ID": "alice", "X-Group-ID": "team"}
+    resp = client.post("/tasks/dummy/disable", headers=headers)
     assert resp.status_code == 200
     assert sched._tasks["dummy"]["disabled"] is True
+
+
+def test_pause_task_missing_headers(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post("/tasks/dummy/pause")
+    assert resp.status_code == 400
+    assert sched._tasks["dummy"]["paused"] is False
+
+
+def test_pause_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    headers = {"X-User-ID": "alice", "X-Group-ID": "team"}
+    resp = client.post("/tasks/dummy/pause", headers=headers)
+    assert resp.status_code == 200
+    assert sched._tasks["dummy"]["paused"] is True
+
+
+def test_resume_task_missing_headers(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    headers = {"X-User-ID": "alice", "X-Group-ID": "team"}
+    client.post("/tasks/dummy/pause", headers=headers)
+    resp = client.post("/tasks/dummy/resume")
+    assert resp.status_code == 400
+    assert sched._tasks["dummy"]["paused"] is True
+
+
+def test_resume_task(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    headers = {"X-User-ID": "alice", "X-Group-ID": "team"}
+    client.post("/tasks/dummy/pause", headers=headers)
+    resp = client.post("/tasks/dummy/resume", headers=headers)
+    assert resp.status_code == 200
+    assert sched._tasks["dummy"]["paused"] is False
 
 
 def test_register_task(monkeypatch, tmp_path):
@@ -233,7 +279,7 @@ def test_register_task(monkeypatch, tmp_path):
     resp = client.post("/tasks", params={"path": "tests.test_api:DynamicTask"})
     assert resp.status_code == 200
     assert "dynamic" in [name for name, _ in sched.list_tasks()]
-    data = yaml.safe_load(open(tmp_path / "tasks.yml").read())
+    yaml.safe_load(open(tmp_path / "tasks.yml").read())
     run = client.post("/tasks/dynamic/run", headers={"X-User-ID": "alice"})
 
     assert run.status_code == 200


### PR DESCRIPTION
## Summary
- require user and group headers when disabling tasks
- test disable, pause, and resume endpoints for missing headers
- verify successful task control when both headers supplied

## Testing
- `ruff check task_cascadence/api/__init__.py tests/test_api.py`
- `pytest tests/test_api.py::test_disable_task_missing_headers tests/test_api.py::test_disable_task tests/test_api.py::test_pause_task_missing_headers tests/test_api.py::test_pause_task tests/test_api.py::test_resume_task_missing_headers tests/test_api.py::test_resume_task -q`

------
https://chatgpt.com/codex/tasks/task_e_689f49ef5a508326b390e8f91dd4de96