### PR TITLE
Propagate user context to task control endpoints

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -149,11 +149,17 @@ def schedule_task(
 
 
 @app.post("/tasks/{name}/disable")
-def disable_task(name: str):
+def disable_task(
+    name: str,
+    user_id: str = Depends(get_user_id),
+    group_id: str | None = Depends(get_group_id),
+):
     """Disable ``name``."""
     sched = get_default_scheduler()
     try:
-        sched.disable_task(name)
+        if user_id is None:
+            raise HTTPException(400, "user_id is required")
+        sched.disable_task(name, user_id=user_id, group_id=group_id)
         return {"status": "disabled"}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -162,7 +168,7 @@ def disable_task(name: str):
 @app.post("/tasks/{name}/pause")
 def pause_task(
     name: str,
-    user_id: str | None = Depends(get_user_id),
+    user_id: str = Depends(get_user_id),
     group_id: str | None = Depends(get_group_id),
 ):
     """Pause ``name`` so it temporarily stops running."""
@@ -174,7 +180,9 @@ def pause_task(
                 raise HTTPException(400, "user_id is required")
             pipeline.pause(user_id=user_id, group_id=group_id)
         else:
-            sched.pause_task(name)
+            if user_id is None:
+                raise HTTPException(400, "user_id is required")
+            sched.pause_task(name, user_id=user_id, group_id=group_id)
         return {"status": "paused"}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -183,7 +191,7 @@ def pause_task(
 @app.post("/tasks/{name}/resume")
 def resume_task(
     name: str,
-    user_id: str | None = Depends(get_user_id),
+    user_id: str = Depends(get_user_id),
     group_id: str | None = Depends(get_group_id),
 ):
     """Resume a previously paused task."""
@@ -195,7 +203,9 @@ def resume_task(
                 raise HTTPException(400, "user_id is required")
             pipeline.resume(user_id=user_id, group_id=group_id)
         else:
-            sched.resume_task(name)
+            if user_id is None:
+                raise HTTPException(400, "user_id is required")
+            sched.resume_task(name, user_id=user_id, group_id=group_id)
         return {"status": "resumed"}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -178,7 +178,13 @@ class BaseScheduler:
             raise RuntimeError("Temporal backend not configured")
         self._temporal.replay(history_path)
 
-    def disable_task(self, name: str) -> None:
+    def disable_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         """Disable a registered task."""
 
         with self._schedules_lock:
@@ -186,7 +192,13 @@ class BaseScheduler:
                 raise ValueError(f"Unknown task: {name}")
             self._tasks[name]["disabled"] = True
 
-    def pause_task(self, name: str) -> None:
+    def pause_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         """Temporarily pause a registered task."""
 
         with self._schedules_lock:
@@ -194,7 +206,13 @@ class BaseScheduler:
                 raise ValueError(f"Unknown task: {name}")
             self._tasks[name]["paused"] = True
 
-    def resume_task(self, name: str) -> None:
+    def resume_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         """Resume a previously paused task."""
 
         with self._schedules_lock:
@@ -595,21 +613,47 @@ class CronScheduler(BaseScheduler):
 
         emit_stage_update_event(name, "unschedule")
 
-    def pause_task(self, name: str) -> None:
+    def disable_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
+        """Disable ``name`` and emit a stage event."""
+
+        super().disable_task(name, user_id=user_id, group_id=group_id)
+        from ..ume import emit_stage_update_event
+
+        emit_stage_update_event(name, "disabled", user_id=user_id, group_id=group_id)
+
+    def pause_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         """Pause ``name`` and emit a stage event."""
 
-        super().pause_task(name)
+        super().pause_task(name, user_id=user_id, group_id=group_id)
         from ..ume import emit_stage_update_event
 
-        emit_stage_update_event(name, "paused")
+        emit_stage_update_event(name, "paused", user_id=user_id, group_id=group_id)
 
-    def resume_task(self, name: str) -> None:
+    def resume_task(
+        self,
+        name: str,
+        *,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
         """Resume ``name`` and emit a stage event."""
 
-        super().resume_task(name)
+        super().resume_task(name, user_id=user_id, group_id=group_id)
         from ..ume import emit_stage_update_event
 
-        emit_stage_update_event(name, "resumed")
+        emit_stage_update_event(name, "resumed", user_id=user_id, group_id=group_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -222,7 +222,7 @@ def test_schedule_task(monkeypatch, tmp_path):
 def test_disable_task(monkeypatch, tmp_path):
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
     client = TestClient(app)
-    resp = client.post("/tasks/dummy/disable")
+    resp = client.post("/tasks/dummy/disable", headers={"X-User-ID": "alice"})
     assert resp.status_code == 200
     assert sched._tasks["dummy"]["disabled"] is True
 
@@ -233,7 +233,7 @@ def test_register_task(monkeypatch, tmp_path):
     resp = client.post("/tasks", params={"path": "tests.test_api:DynamicTask"})
     assert resp.status_code == 200
     assert "dynamic" in [name for name, _ in sched.list_tasks()]
-    data = yaml.safe_load(open(tmp_path / "tasks.yml").read())
+    yaml.safe_load(open(tmp_path / "tasks.yml").read())
     run = client.post("/tasks/dynamic/run", headers={"X-User-ID": "alice"})
 
     assert run.status_code == 200


### PR DESCRIPTION
## Summary
- accept user_id and group_id on disable, pause, and resume endpoints
- forward identifiers to scheduler or pipeline operations
- capture user context when pausing or resuming tasks

## Testing
- `ruff check task_cascadence tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f49eea888832681b29ff5474d3b8d