### PR TITLE
Validate payload group ID

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -59,6 +59,18 @@ def create_calendar_event(
         if field not in payload or not payload[field]:
             raise ValueError(f"missing required field: {field}")
 
+    payload_group_id = payload.get("group_id")
+    if payload_group_id is not None and payload_group_id != group_id:
+        emit_audit_log(
+            "calendar.event.create",
+            "workflow",
+            "error",
+            reason="group_id mismatch",
+            user_id=user_id,
+            group_id=group_id,
+        )
+        raise ValueError("group_id mismatch")
+
     travel_info: Dict[str, Any] | None = None
     travel_future: Future | None = None
     travel_executor: ThreadPoolExecutor | None = None


### PR DESCRIPTION
## Summary
- ensure `create_calendar_event` checks payload `group_id` against argument and logs mismatches
- cover mismatched group id case with unit test

## Testing
- `ruff check .`
- `pytest tests/test_calendar_workflow.py::test_calendar_event_group_id_mismatch tests/test_calendar_workflow.py::test_calendar_event_creation -q`

------
https://chatgpt.com/codex/tasks/task_e_689f5808774883269804f8628f53d439