### PR TITLE
Propagate user context in scheduler calendar lookups

### DIFF
--- a/tests/test_task_context.py
+++ b/tests/test_task_context.py
@@ -47,3 +47,25 @@ async def test_task_pipeline_context_async(monkeypatch):
     assert task.seen_group_id == "team2"
     assert task.user_id == "bob"
     assert task.group_id == "team2"
+
+
+def test_scheduler_sets_task_context(monkeypatch):
+    from task_cascadence.scheduler import BaseScheduler
+
+    class SimpleTask:
+        def run(self):
+            self.seen_user_id = self.user_id
+            self.seen_group_id = self.group_id
+            return "ok"
+
+    monkeypatch.setattr(
+        "task_cascadence.ume.emit_task_run", lambda *a, **k: None
+    )
+    sched = BaseScheduler()
+    sched.register_task("simple", SimpleTask())
+    sched.run_task("simple", user_id="alice", group_id="team1")
+    task = sched._tasks["simple"]["task"]
+    assert task.seen_user_id == "alice"
+    assert task.seen_group_id == "team1"
+    assert task.user_id == "alice"
+    assert task.group_id == "team1"

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -63,8 +63,9 @@ def test_yaml_calendar_event_daily(tmp_path, monkeypatch):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
 
-    def fake_fetch(self, node):
+    def fake_fetch(self, node, *, user_id=None, group_id=None):
         assert node == "evt1"
+        assert user_id is None and group_id is None
         return {"recurrence": {"cron": "0 9 * * *"}}
 
     monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)
@@ -84,8 +85,9 @@ def test_yaml_calendar_event_weekly(tmp_path, monkeypatch):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
 
-    def fake_fetch(self, node):
+    def fake_fetch(self, node, *, user_id=None, group_id=None):
         assert node == "evt2"
+        assert user_id is None and group_id is None
         return {"recurrence": {"cron": "30 10 * * 1"}}
 
     monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)
@@ -111,8 +113,10 @@ def test_yaml_calendar_event_multiple_recurrences(tmp_path, monkeypatch):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     task = DummyTask()
 
-    def fake_fetch(self, node):
+    def fake_fetch(self, node, *, user_id=None, group_id=None):
         assert node == "evt3"
+        assert user_id == "alice"
+        assert group_id == "engineering"
         return {"recurrence": {"cron": "*/2 * * * *"}}
 
     monkeypatch.setattr(CronScheduler, "_fetch_calendar_event", fake_fetch)


### PR DESCRIPTION
## Summary
- include user and group identifiers when fetching calendar events
- ensure plain tasks receive user_id/group_id before execution
- propagate context through calendar polling and YAML loading

## Testing
- `ruff check .`
- `pytest tests/test_yaml_schedule.py tests/test_task_context.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0afa351608326aea0c5c1b53cc06f