### PR TITLE
Add test for BaseScheduler user context assignment

### DIFF
--- a/tests/test_run_task_user_context.py
+++ b/tests/test_run_task_user_context.py
@@ -1,0 +1,16 @@
+from task_cascadence.scheduler import BaseScheduler
+
+
+class MinimalTask:
+    def run(self):  # pragma: no cover - behaviour tested via scheduler
+        pass
+
+
+def test_run_task_sets_user_and_group(monkeypatch):
+    monkeypatch.setattr("task_cascadence.ume.emit_task_run", lambda *a, **k: None)
+    task = MinimalTask()
+    scheduler = BaseScheduler()
+    scheduler.register_task("minimal", task)
+    scheduler.run_task("minimal", user_id="u1", group_id="g1")
+    assert task.user_id == "u1"
+    assert task.group_id == "g1"


### PR DESCRIPTION
## Summary
- add unit test ensuring `BaseScheduler.run_task` assigns user and group IDs to tasks

## Testing
- `ruff check tests/test_run_task_user_context.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bdaecf808326bba4e8bcef74a38d