### PR TITLE
Use asyncio tasks for travel time lookup

### DIFF
--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -373,7 +373,7 @@ async def test_calendar_event_creation_in_event_loop(monkeypatch):
         "location": "Cafe",
     }
 
-    result = dispatch("calendar.event.create_request", payload, user_id="alice")
+    result = await cec.create_calendar_event(payload, user_id="alice")
 
     assert result == {"event_id": "evt1", "related_event_id": "evt2"}
     assert (
@@ -426,8 +426,8 @@ async def test_calendar_event_research_failure_in_event_loop(monkeypatch):
         "location": "Cafe",
     }
 
-    result = dispatch(
-        "calendar.event.create_request", payload, user_id="alice", base_url="http://svc"
+    result = await cec.create_calendar_event(
+        payload, user_id="alice", base_url="http://svc"
     )
 
     assert result == {"event_id": "evt1"}


### PR DESCRIPTION
## Summary
- Fetch travel time with `asyncio.create_task` and await it, cancelling on permission errors
- Support awaiting workflows in `dispatch`
- Exercise async calendar workflow paths in tests

## Testing
- `ruff check task_cascadence/workflows/calendar_event_creation.py task_cascadence/workflows/__init__.py tests/test_calendar_workflow.py`
- `pytest tests/test_calendar_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_68a336c14a6083268259cfc515d11a45