### PR TITLE
Use ume_base for calendar persistence

### DIFF
--- a/task_cascadence/workflows/calendar_event_creation.py
+++ b/task_cascadence/workflows/calendar_event_creation.py
@@ -42,7 +42,6 @@ async def create_calendar_event(
     *,
     user_id: str,
     group_id: str | None = None,
-    base_url: str = "http://localhost",
     ume_base: str = "http://ume",
 ) -> Dict[str, Any]:
     """Persist calendar events after validation and permission checks."""
@@ -188,7 +187,7 @@ async def create_calendar_event(
         note_text = f"Travel time to {payload['location']}: {duration}"
     note = TaskNote(note=note_text)
 
-    url = f"{base_url.rstrip('/')}/v1/calendar/events"
+    url = f"{ume_base.rstrip('/')}/v1/calendar/events"
     try:
         resp = request_with_retry("POST", url, json=event_data, timeout=5)
     except Exception as exc:
@@ -212,7 +211,7 @@ async def create_calendar_event(
         main_event = resp.json()
         main_id = main_event.get("id")
 
-    edge_url = f"{base_url.rstrip('/')}/v1/calendar/edges"
+    edge_url = f"{ume_base.rstrip('/')}/v1/calendar/edges"
 
     related_id = None
     if related_event is not None:

--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -96,7 +96,7 @@ def test_calendar_event_creation(monkeypatch):
     }
 
     result = dispatch(
-        "calendar.event.create_request", payload, user_id="alice", group_id="g1", base_url="http://svc"
+        "calendar.event.create_request", payload, user_id="alice", group_id="g1", ume_base="http://svc"
     )
 
     assert result == {"event_id": "evt1", "related_event_id": "evt2"}
@@ -249,7 +249,7 @@ def test_calendar_event_ume_failure(monkeypatch):
     }
 
     result = dispatch(
-        "calendar.event.create_request", payload, user_id="alice", base_url="http://svc"
+        "calendar.event.create_request", payload, user_id="alice", ume_base="http://svc"
     )
 
     assert result == {"event_id": "evt1", "related_event_id": "evt2"}
@@ -311,7 +311,7 @@ def test_calendar_event_research_failure(monkeypatch):
     }
 
     result = dispatch(
-        "calendar.event.create_request", payload, user_id="alice", base_url="http://svc"
+        "calendar.event.create_request", payload, user_id="alice", ume_base="http://svc"
     )
 
     assert result == {"event_id": "evt1"}
@@ -427,7 +427,7 @@ async def test_calendar_event_research_failure_in_event_loop(monkeypatch):
     }
 
     result = await cec.create_calendar_event(
-        payload, user_id="alice", base_url="http://svc"
+        payload, user_id="alice", ume_base="http://svc"
     )
 
     assert result == {"event_id": "evt1"}


### PR DESCRIPTION
## Summary
- use `ume_base` for calendar event and edge persistence calls
- adjust calendar workflow tests to pass unified base URL parameter

## Testing
- `ruff check task_cascadence/workflows/calendar_event_creation.py tests/test_calendar_workflow.py`
- `pytest tests/test_calendar_workflow.py tests/test_calendar_persistence_error.py` *(fails: HTTPError 503 when hitting ume permissions endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68a70984dde0832689121e8b61bc3bcf