### PR TITLE
Validate required fields in YAML schedule loading

### DIFF
--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -38,6 +38,50 @@ def test_load_yaml_malformed(tmp_path):
         sched.load_yaml(cfg, {"DummyTask": DummyTask()})
 
 
+def test_load_yaml_missing_required_fields(tmp_path):
+    data = {"DummyTask": {}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    with pytest.raises(
+        ValueError, match="DummyTask: missing 'expr' or 'calendar_event'"
+    ):
+        sched.load_yaml(cfg, {"DummyTask": DummyTask()})
+
+
+def test_load_yaml_calendar_event_missing_node(tmp_path):
+    data = {"DummyTask": {"calendar_event": {}}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    with pytest.raises(
+        ValueError, match="calendar_event missing 'node'"
+    ):
+        sched.load_yaml(cfg, {"DummyTask": DummyTask()})
+
+
+def test_load_yaml_calendar_event_invalid_type(tmp_path):
+    data = {"DummyTask": {"calendar_event": 123}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    with pytest.raises(
+        ValueError, match="'calendar_event' must be string or mapping"
+    ):
+        sched.load_yaml(cfg, {"DummyTask": DummyTask()})
+
+
+def test_load_yaml_expr_invalid_type(tmp_path):
+    data = {"DummyTask": {"expr": 123}}
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
+    with pytest.raises(
+        ValueError, match="'expr' must be a non-empty string"
+    ):
+        sched.load_yaml(cfg, {"DummyTask": DummyTask()})
+
+
 def test_schedule_from_calendar_event(tmp_path):
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "sched.yml")
     sched.start()


### PR DESCRIPTION
## Summary
- ensure YAML schedule entries include either `expr` or `calendar_event.node`
- raise descriptive `ValueError`s for missing or invalid schedule fields
- add tests covering malformed schedule configurations

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/test_yaml_schedule.py`
- `pytest` *(fails: Default scheduler has not been initialised; stages.yml missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a72933e75c8326bc9edf3a5f7fff5d