### PR TITLE
Hash user ID before calendar fetch

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -382,6 +382,8 @@ class CronScheduler(BaseScheduler):
             raise RuntimeError("UME_BASE_URL not configured")
         node = node.lstrip("/")
         url = f"{base.rstrip('/')}/v1/calendar/nodes/{node}"
+        if user_id is not None:
+            user_id = _maybe_hash_user_id(user_id)
         params: dict[str, str] = {}
         if user_id is not None:
             params["user_id"] = user_id


### PR DESCRIPTION
## Summary
- Hash user_id before requesting calendar events from UME

## Testing
- `pytest tests/test_scheduler.py -q`
- `pytest tests/test_scheduler_running.py -q`
- `pytest tests/test_poll_calendar_event.py -q`
- `pytest tests/test_schedule_from_event.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adace382ac8326aa4c9e1c61a4116e