### PR TITLE
Test calendar fetch user_id hashing

### DIFF
--- a/task_cascadence/plugins/__init__.py
+++ b/task_cascadence/plugins/__init__.py
@@ -15,7 +15,10 @@ from ..ume.models import TaskPointer
 from ..pointer_store import PointerStore
 
 
-from ..scheduler import get_default_scheduler
+def _scheduler_module():
+    from .. import scheduler
+
+    return scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +168,7 @@ def load_entrypoint_plugins() -> None:
     for ep in metadata.entry_points().select(group="task_cascadence.plugins"):
         task = load_plugin(ep.value)
         registered_tasks[task.name] = task
-        get_default_scheduler().register_task(task.name, task)
+        _scheduler_module().get_default_scheduler().register_task(task.name, task)
 
 
 def load_cronyx_plugins(base_url: str) -> None:
@@ -178,14 +181,14 @@ def load_cronyx_plugins(base_url: str) -> None:
         data = loader.load_task(info["id"])
         task = load_plugin(data["path"])
         registered_tasks[task.name] = task
-        get_default_scheduler().register_task(task.name, task)
+        _scheduler_module().get_default_scheduler().register_task(task.name, task)
 
 
 def initialize() -> None:
     """Register built-in tasks and load any external plugins."""
 
     for _name, _task in registered_tasks.items():
-        get_default_scheduler().register_task(_name, _task)
+        _scheduler_module().get_default_scheduler().register_task(_name, _task)
 
     load_entrypoint_plugins()
 
@@ -215,7 +218,7 @@ def load_cronyx_tasks() -> None:
             cls = getattr(mod, cls_name)
             obj = cls()
             registered_tasks[obj.name] = obj
-            get_default_scheduler().register_task(obj.name, obj)
+            _scheduler_module().get_default_scheduler().register_task(obj.name, obj)
     except Exception:  # pragma: no cover - best effort loading
         pass
 

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -384,7 +384,7 @@ class CronScheduler(BaseScheduler):
         url = f"{base.rstrip('/')}/v1/calendar/nodes/{node}"
         params: dict[str, str] = {}
         if user_id is not None:
-            params["user_id"] = user_id
+            params["user_id"] = _maybe_hash_user_id(user_id)
         if group_id is not None:
             params["group_id"] = group_id
         response = request_with_retry("GET", url, timeout=5, params=params or None)

--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -23,6 +23,7 @@ class StageStore:
             path = Path.home() / ".cascadence" / "stages.yml"
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
         self._data: Dict[str, List[Dict[str, Any]]] = self._load()
 
     def _load(self) -> Dict[str, List[Dict[str, Any]]]:

--- a/tests/test_scheduler_calendar_hash.py
+++ b/tests/test_scheduler_calendar_hash.py
@@ -1,0 +1,23 @@
+from task_cascadence.scheduler import CronScheduler
+import task_cascadence.scheduler as scheduler
+
+
+class DummyResp:
+    def json(self) -> dict:
+        return {}
+
+
+def test_fetch_calendar_event_hashes_user_id(monkeypatch, tmp_path):
+    captured: dict[str, dict | None] = {}
+
+    def fake_request(method, url, timeout=0, **kwargs):
+        captured["params"] = kwargs.get("params")
+        return DummyResp()
+
+    monkeypatch.setattr(scheduler, "request_with_retry", fake_request)
+    monkeypatch.setenv("UME_BASE_URL", "http://ume")
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    sched._fetch_calendar_event("foo", user_id="alice")
+    from task_cascadence.ume import _hash_user_id
+
+    assert captured["params"]["user_id"] == _hash_user_id("alice")


### PR DESCRIPTION
## Summary
- hash user_id before sending calendar fetch queries
- add test ensuring CronScheduler sends hashed user IDs when fetching calendar events
- look up the current scheduler dynamically when loading plugins
- ensure stage event log file exists so pipeline tests can read stage data

## Testing
- `ruff check task_cascadence/stage_store.py tests/test_calendar_workflow.py tests/test_orchestrator.py tests/test_task_context.py tests/test_ume_events.py tests/test_scheduler_running.py tests/test_mypy.py`
- `pytest tests/test_calendar_workflow.py::test_calendar_event_creation_in_event_loop tests/test_calendar_workflow.py::test_calendar_event_research_failure_in_event_loop tests/test_orchestrator.py::test_subtask_results_resolved_async tests/test_task_context.py::test_task_pipeline_context_async tests/test_ume_events.py::test_pipeline_stage_events tests/test_scheduler_running.py::test_scheduler_running_after_initialize tests/test_mypy.py::test_mypy_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_68adace45c60832682124ac48e8c5cce