### PR TITLE
test: cover negative budgets and missing fields

### DIFF
--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -375,7 +375,11 @@ def test_financial_decision_support_persistence_failure(monkeypatch):
 
 @pytest.mark.parametrize(
     "payload,missing",
-    [({"max_options": 3}, "budget"), ({"budget": 100}, "max_options")],
+    [
+        ({"max_options": 3}, ["budget"]),
+        ({"budget": 100}, ["max_options"]),
+        ({}, ["budget", "max_options"]),
+    ],
 )
 def test_financial_decision_support_missing_fields(monkeypatch, payload, missing):
     calls = []
@@ -422,7 +426,8 @@ def test_financial_decision_support_missing_fields(monkeypatch, payload, missing
     assert any(
         a[1] == "workflow"
         and a[2] == "error"
-        and a[3] == f"Missing required fields: {missing}"
+        and set(a[3].replace("Missing required fields: ", "").split(", "))
+        == set(missing)
         and a[5] == "alice"
         and a[6] is None
         for a in audit_logs
@@ -433,8 +438,66 @@ def test_financial_decision_support_missing_fields(monkeypatch, payload, missing
     "payload,field",
     [
         ({"budget": -1, "max_options": 1}, "budget"),
-        ({"budget": "100", "max_options": 1}, "budget"),
         ({"budget": 100, "max_options": -1}, "max_options"),
+    ],
+)
+# Negative budgets or max_options should produce an error and audit log entry
+def test_financial_decision_support_negative_values(monkeypatch, payload, field):
+    calls = []
+
+    def fake_request(method, url, timeout, **kwargs):
+        calls.append((method, url, kwargs))
+        return DummyResponse({})
+
+    emitted = []
+
+    def fake_emit(name, stage, user_id=None, group_id=None, **_):
+        emitted.append((name, stage, user_id, group_id))
+
+    dispatched = []
+
+    def fake_dispatch(event, payload, user_id, group_id=None):
+        dispatched.append(event)
+
+    audit_logs = []
+
+    def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
+        audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
+
+    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
+    monkeypatch.setattr(fds, "dispatch", fake_dispatch)
+    monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
+
+    with pytest.raises(ValueError):
+        dispatch("finance.decision.request", payload, user_id="alice")
+
+    assert calls == []
+    assert emitted == [("finance.decision.result", "error", "alice", None)]
+    assert "finance.decision.result" not in dispatched
+    assert (
+        "finance.decision",
+        "workflow",
+        "started",
+        None,
+        None,
+        "alice",
+        None,
+    ) in audit_logs
+    assert any(
+        a[1] == "workflow"
+        and a[2] == "error"
+        and a[3] == f"Invalid {field}: must be non-negative numbers"
+        and a[5] == "alice"
+        and a[6] is None
+        for a in audit_logs
+    )
+
+
+@pytest.mark.parametrize(
+    "payload,field",
+    [
+        ({"budget": "100", "max_options": 1}, "budget"),
         ({"budget": 100, "max_options": "3"}, "max_options"),
     ],
 )
@@ -483,7 +546,7 @@ def test_financial_decision_support_invalid_values(monkeypatch, payload, field):
     assert any(
         a[1] == "workflow"
         and a[2] == "error"
-        and field in (a[3] or "")
+        and a[3] == f"Invalid {field}: must be non-negative numbers"
         and a[5] == "alice"
         and a[6] is None
         for a in audit_logs


### PR DESCRIPTION
## Summary
- extend missing-field checks for financial decision workflow
- validate negative budget and max_options emit audit logs

## Testing
- `ruff check tests/test_financial_decision_support.py`
- `pytest` *(fails: FileNotFoundError in test_ume_events.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af11edb3488326bd9d8c01286a8965