### PR TITLE
feat: persist partial audit payload

### DIFF
--- a/task_cascadence/stage_store.py
+++ b/task_cascadence/stage_store.py
@@ -80,6 +80,7 @@ class StageStore:
         status: str | None = None,
         reason: str | None = None,
         output: str | None = None,
+        partial: Any | None = None,
         category: str = "stage",
     ) -> None:
         entry: Dict[str, Any] = {
@@ -92,6 +93,8 @@ class StageStore:
             entry["reason"] = reason
         if output is not None:
             entry["output"] = output
+        if partial is not None:
+            entry["partial"] = partial
         if user_hash is not None:
             entry["user_hash"] = user_hash
         if group_id is not None:

--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -131,12 +131,18 @@ def emit_audit_log(
     *,
     reason: str | None = None,
     output: str | None = None,
+    partial: Any | None = None,
     user_id: str | None = None,
     group_id: str | None = None,
 
     use_asyncio: bool = False,
 ) -> asyncio.Task | threading.Thread | None:
-    """Persist and emit an audit log entry using the configured transport."""
+    """Persist and emit an audit log entry using the configured transport.
+
+    ``partial`` can be supplied with a serialized representation of any data
+    produced before a failure.  This payload is persisted so that execution can
+    recover or resume later.
+    """
 
     store = _get_stage_store()
     user_hash = _hash_user_id(user_id) if user_id is not None else None
@@ -148,6 +154,7 @@ def emit_audit_log(
         status=status,
         reason=reason,
         output=output,
+        partial=partial,
         category="audit",
     )
     target = client or _default_client
@@ -158,6 +165,8 @@ def emit_audit_log(
         event.reason = reason
     if output is not None:
         event.output = output
+    if partial is not None:
+        event.partial = partial
     if user_id is not None:
         event.user_id = user_id
         event.user_hash = _hash_user_id(user_id)


### PR DESCRIPTION
## Summary
- allow `emit_audit_log` to send and persist partial payloads for recovery
- record `partial` data in `StageStore` events

## Testing
- `ruff check task_cascadence/ume/__init__.py task_cascadence/stage_store.py`
- `pytest tests/test_ume.py tests/test_ume_events.py tests/test_ume_patterns.py tests/test_audit_log.py tests/test_stage_store.py tests/test_scheduler_audit_logs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af1d73c4788326896f0ce9edeb4424