### PR TITLE
test: hash user id when loading schedule

### DIFF
--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -104,6 +104,19 @@ def test_schedule_from_calendar_event(tmp_path):
     assert persisted["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
 
 
+def test_loads_plain_user_id_and_rewrites(tmp_path):
+    sched_file = tmp_path / "sched.yml"
+    data = {"DummyTask": {"expr": "* * * * *", "user_id": "alice"}}
+    sched_file.write_text(yaml.safe_dump(data))
+    sched = CronScheduler(timezone="UTC", storage_path=sched_file)
+    from task_cascadence.ume import _hash_user_id
+
+    expected = _hash_user_id("alice")
+    assert sched.schedules["DummyTask"]["user_id"] == expected
+    persisted = yaml.safe_load(sched_file.read_text())
+    assert persisted["DummyTask"]["user_id"] == expected
+
+
 def test_yaml_calendar_event_daily(tmp_path, monkeypatch):
     data = {"DummyTask": {"calendar_event": "evt1"}}
     cfg = tmp_path / "config.yml"


### PR DESCRIPTION
## Summary
- test that CronScheduler hashes and rewrites plain user IDs in schedule files

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e93b85608326bf4cc2d48f4a66db