### PR TITLE
Hash group IDs in scheduler operations

### DIFF
--- a/tests/test_poll_calendar_event.py
+++ b/tests/test_poll_calendar_event.py
@@ -33,4 +33,4 @@ def test_poll_calendar_event(monkeypatch, tmp_path):
     from task_cascadence.ume import _hash_user_id
 
     assert entry["user_id"] == _hash_user_id("alice")
-    assert entry["group_id"] == "engineering"
+    assert entry["group_id"] == _hash_user_id("engineering")

--- a/tests/test_schedule_from_event.py
+++ b/tests/test_schedule_from_event.py
@@ -25,7 +25,7 @@ def test_schedule_from_event_registers_metadata(tmp_path):
     from task_cascadence.ume import _hash_user_id
 
     assert entry["user_id"] == _hash_user_id("alice")
-    assert entry["group_id"] == "engineering"
+    assert entry["group_id"] == _hash_user_id("engineering")
 
 
 def test_yaml_recurrence_loaded(tmp_path):

--- a/tests/test_scheduler_audit_logs.py
+++ b/tests/test_scheduler_audit_logs.py
@@ -57,15 +57,33 @@ def test_scheduler_audit_logs(monkeypatch, tmp_path):
     sched.unschedule("Dummy")
 
     assert calls == [
-        ("Dummy", "scheduler", "disabled", "alice", "team"),
-        ("Dummy", "scheduler", "paused", "alice", "team"),
-        ("Dummy", "scheduler", "resumed", "alice", "team"),
+        (
+            "Dummy",
+            "scheduler",
+            "disabled",
+            "alice",
+            ume_mod._hash_user_id("team"),
+        ),
+        (
+            "Dummy",
+            "scheduler",
+            "paused",
+            "alice",
+            ume_mod._hash_user_id("team"),
+        ),
+        (
+            "Dummy",
+            "scheduler",
+            "resumed",
+            "alice",
+            ume_mod._hash_user_id("team"),
+        ),
         (
             "Dummy",
             "unschedule",
             "success",
             ume_mod._hash_user_id("alice"),
-            "team",
+            ume_mod._hash_user_id("team"),
         ),
     ]
 

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -97,24 +97,33 @@ def test_schedule_from_calendar_event(tmp_path):
     from task_cascadence.ume import _hash_user_id
 
     assert entry["user_id"] == _hash_user_id("alice")
-    assert entry["group_id"] == "engineering"
+    assert entry["group_id"] == _hash_user_id("engineering")
     persisted = yaml.safe_load((tmp_path / "sched.yml").read_text())
     assert persisted["DummyTask"]["user_id"] == _hash_user_id("alice")
-    assert persisted["DummyTask"]["group_id"] == "engineering"
+    assert persisted["DummyTask"]["group_id"] == _hash_user_id("engineering")
     assert persisted["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
 
 
-def test_loads_plain_user_id_and_rewrites(tmp_path):
+def test_loads_plain_identifiers_and_rewrites(tmp_path):
     sched_file = tmp_path / "sched.yml"
-    data = {"DummyTask": {"expr": "* * * * *", "user_id": "alice"}}
+    data = {
+        "DummyTask": {
+            "expr": "* * * * *",
+            "user_id": "alice",
+            "group_id": "engineering",
+        }
+    }
     sched_file.write_text(yaml.safe_dump(data))
     sched = CronScheduler(timezone="UTC", storage_path=sched_file)
     from task_cascadence.ume import _hash_user_id
 
-    expected = _hash_user_id("alice")
-    assert sched.schedules["DummyTask"]["user_id"] == expected
+    expected_user = _hash_user_id("alice")
+    expected_group = _hash_user_id("engineering")
+    assert sched.schedules["DummyTask"]["user_id"] == expected_user
+    assert sched.schedules["DummyTask"]["group_id"] == expected_group
     persisted = yaml.safe_load(sched_file.read_text())
-    assert persisted["DummyTask"]["user_id"] == expected
+    assert persisted["DummyTask"]["user_id"] == expected_user
+    assert persisted["DummyTask"]["group_id"] == expected_group
 
 
 def test_yaml_calendar_event_daily(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- hash group IDs when loading/saving cron schedules and when emitting schedule events
- add `_maybe_hash_group_id` helper mirroring user ID hashing
- update tests for hashed group ID persistence and audit logs

## Testing
- `ruff check`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b842bc581c83268ce5a7f675902ef6