### PR TITLE
test: verify group ID hashing

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -177,14 +177,17 @@ class BaseScheduler:
                         started_at=started,
                         finished_at=finished,
                     )
-                    if user_id is None and group_id is None:
+                    group_hash = (
+                        _maybe_hash_group_id(group_id) if group_id is not None else None
+                    )
+                    if user_id is None and group_hash is None:
                         emit_task_run(run)
-                    elif group_id is None:
+                    elif group_hash is None:
                         emit_task_run(run, user_id=user_id)
                     elif user_id is None:
-                        emit_task_run(run, group_id=group_id)
+                        emit_task_run(run, group_id=group_hash)
                     else:
-                        emit_task_run(run, user_id=user_id, group_id=group_id)
+                        emit_task_run(run, user_id=user_id, group_id=group_hash)
                 return result
 
             return runner()

--- a/tests/test_scheduler_calendar_hash.py
+++ b/tests/test_scheduler_calendar_hash.py
@@ -1,5 +1,10 @@
 from task_cascadence.scheduler import CronScheduler
 import task_cascadence.scheduler as scheduler
+from task_cascadence.ume import _hash_user_id
+
+
+def expected_hash(value: str) -> str:
+    return _hash_user_id(value)
 
 
 class DummyResp:
@@ -7,7 +12,7 @@ class DummyResp:
         return {}
 
 
-def test_fetch_calendar_event_hashes_user_id(monkeypatch, tmp_path):
+def test_fetch_calendar_event_hashes_identifiers(monkeypatch, tmp_path):
     captured: dict[str, dict | None] = {}
 
     def fake_request(method, url, timeout=0, **kwargs):
@@ -17,7 +22,23 @@ def test_fetch_calendar_event_hashes_user_id(monkeypatch, tmp_path):
     monkeypatch.setattr(scheduler, "request_with_retry", fake_request)
     monkeypatch.setenv("UME_BASE_URL", "http://ume")
     sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
-    sched._fetch_calendar_event("foo", user_id="alice")
-    from task_cascadence.ume import _hash_user_id
+    sched._fetch_calendar_event("foo", user_id="alice", group_id="engineering")
 
-    assert captured["params"]["user_id"] == _hash_user_id("alice")
+    assert captured["params"]["user_id"] == expected_hash("alice")
+    assert captured["params"]["group_id"] == expected_hash("engineering")
+
+
+def test_register_task_hashes_group_id(tmp_path):
+    class DummyTask:
+        def run(self):
+            pass
+
+    sched = CronScheduler(timezone="UTC", storage_path=tmp_path / "s.yml")
+    task = DummyTask()
+    sched.register_task(task, "* * * * *", user_id="alice", group_id="engineering")
+    entry = sched.schedules["DummyTask"]
+    assert entry["group_id"] == expected_hash("engineering")
+    import yaml
+
+    persisted = yaml.safe_load((tmp_path / "s.yml").read_text())
+    assert persisted["DummyTask"]["group_id"] == expected_hash("engineering")


### PR DESCRIPTION
## Summary
- hash group IDs when emitting task run events
- test group ID hashing across scheduler calendar and YAML persistence

## Testing
- `ruff check task_cascadence/scheduler/__init__.py tests/test_scheduler_calendar_hash.py tests/test_yaml_schedule.py`
- `pytest tests/test_scheduler_calendar_hash.py tests/test_yaml_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_68b851b6e7cc8326b99a375d5550cbff