### PR TITLE
Add audit recovery helper

### DIFF
--- a/task_cascadence/audit_recovery.py
+++ b/task_cascadence/audit_recovery.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .stage_store import StageStore
+from .ume import _hash_user_id
+
+
+def recover_partial(
+    task_name: str,
+    stage: str,
+    *,
+    user_id: str | None = None,
+    group_id: str | None = None,
+) -> Any | None:
+    """Return the most recent partial payload for *task_name* and *stage*.
+
+    Parameters
+    ----------
+    task_name:
+        Name of the task whose audit log should be queried.
+    stage:
+        Stage name to look up within the audit events.
+    user_id:
+        Optional user identifier. When provided it is hashed in the same way as
+        :func:`task_cascadence.ume.emit_audit_log` so that per-user isolation is
+        respected.
+    group_id:
+        Optional group identifier to further scope the lookup.
+
+    Returns
+    -------
+    Any | None
+        The stored ``partial`` payload if one exists, otherwise ``None``.
+    """
+
+    store = StageStore()
+    user_hash = _hash_user_id(user_id) if user_id is not None else None
+    events = store.get_events(
+        task_name,
+        user_hash=user_hash,
+        group_id=group_id,
+        category="audit",
+    )
+    for event in reversed(events):
+        if event.get("stage") == stage and "partial" in event:
+            return event["partial"]
+    return None

--- a/tests/test_audit_recovery.py
+++ b/tests/test_audit_recovery.py
@@ -1,0 +1,27 @@
+from task_cascadence.audit_recovery import recover_partial
+from task_cascadence.stage_store import StageStore
+from task_cascadence.ume import _hash_user_id
+
+
+def test_recover_partial_payload(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "stages.yml"))
+    store = StageStore()
+
+    user_id = "alice"
+    group_id = "g1"
+    user_hash = _hash_user_id(user_id)
+
+    store.add_event(
+        "ExampleTask",
+        "research",
+        user_hash=user_hash,
+        group_id=group_id,
+        partial=["step1"],
+        category="audit",
+    )
+
+    recovered = recover_partial("ExampleTask", "research", user_id=user_id, group_id=group_id)
+    assert recovered == ["step1"]
+
+    recovered.append("step2")
+    assert recovered == ["step1", "step2"]


### PR DESCRIPTION
## Summary
- add helper to recover partial audit payloads from StageStore
- test that stored partial payloads can be retrieved and used to resume processing

## Testing
- `ruff check task_cascadence/audit_recovery.py tests/test_audit_recovery.py`
- `pytest tests/test_audit_recovery.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef76eccfc8326894e1755af6aac8a