### PR TITLE
Propagate context through pointer synchronization

### DIFF
--- a/tests/test_pointer_sync_service.py
+++ b/tests/test_pointer_sync_service.py
@@ -151,7 +151,11 @@ class Stub:
     monkeypatch.setenv("UME_GRPC_STUB", "stub_b:Stub")
 
     importlib.invalidate_caches()
-    monkeypatch.setattr(pointer_sync, "emit_pointer_update", __import__("stub_b").Stub.Send)
+    monkeypatch.setattr(
+        pointer_sync,
+        "emit_pointer_update",
+        lambda update, **_: __import__("stub_b").Stub.Send(update),
+    )
     pointer_sync.run()
 
     data = yaml.safe_load(store_a.read_text())


### PR DESCRIPTION
## Summary
- forward user and group identifiers with pointer updates
- audit successful and failed pointer synchronization events
- add tests ensuring context is passed through and failures are logged

## Testing
- `ruff check task_cascadence tests`
- `pytest tests/test_pointer_sync.py tests/test_pointer_sync_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03cb60e188326ada2f2f29a9e0e06