### PR TITLE
feat: add async HTTP retry and update financial workflow

### DIFF
--- a/task_cascadence/http_utils.py
+++ b/task_cascadence/http_utils.py
@@ -1,7 +1,9 @@
+import asyncio
 import time
 from typing import Any, Optional
 
 import requests
+import httpx
 
 
 def request_with_retry(
@@ -25,4 +27,31 @@ def request_with_retry(
             if attempt == retries:
                 raise
             time.sleep(backoff_factor * 2 ** (attempt - 1))
+    raise RuntimeError("unreachable")
+
+
+async def request_with_retry_async(
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+    client: Optional[httpx.AsyncClient] = None,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Asynchronously perform an HTTP request with simple retry logic."""
+    for attempt in range(1, retries + 1):
+        try:
+            if client is None:
+                async with httpx.AsyncClient() as c:
+                    response = await c.request(method, url, timeout=timeout, **kwargs)
+            else:
+                response = await client.request(method, url, timeout=timeout, **kwargs)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPError:
+            if attempt == retries:
+                raise
+            await asyncio.sleep(backoff_factor * 2 ** (attempt - 1))
     raise RuntimeError("unreachable")

--- a/tests/test_finance_explain.py
+++ b/tests/test_finance_explain.py
@@ -19,7 +19,7 @@ class DummyResponse:
 
 
 def _setup(monkeypatch):
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         if method == "GET":
             return DummyResponse({"nodes": []})
         elif url.endswith("/v1/simulations/debt"):
@@ -27,7 +27,7 @@ def _setup(monkeypatch):
         else:
             return DummyResponse({"ok": True})
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
     monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
 

--- a/tests/test_financial_decision_support.py
+++ b/tests/test_financial_decision_support.py
@@ -28,7 +28,7 @@ class DummyResponse:
 def test_financial_decision_support(monkeypatch):
     calls: list[tuple[str, str, dict[str, Any]]] = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             assert kwargs["params"]["user_id"] == "alice"
@@ -78,7 +78,7 @@ def test_financial_decision_support(monkeypatch):
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -138,7 +138,7 @@ def test_financial_decision_support(monkeypatch):
 
 
 def test_financial_decision_support_group_id_mismatch(monkeypatch):
-    def fake_request(*a, **k):
+    async def fake_request(*a, **k):
         raise AssertionError("request should not be called")
 
     audit_logs = []
@@ -146,7 +146,7 @@ def test_financial_decision_support_group_id_mismatch(monkeypatch):
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
     monkeypatch.setattr(fds, "dispatch", lambda *a, **k: None)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -181,7 +181,7 @@ def test_financial_decision_support_group_id_mismatch(monkeypatch):
 def test_financial_decision_support_time_horizon(monkeypatch):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             return DummyResponse({"nodes": []})
@@ -190,7 +190,7 @@ def test_financial_decision_support_time_horizon(monkeypatch):
         else:
             return DummyResponse({"ok": True})
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", lambda *a, **k: None)
     monkeypatch.setattr(fds, "dispatch", lambda *a, **k: None)
     monkeypatch.setattr(fds, "emit_audit_log", lambda *a, **k: None)
@@ -213,7 +213,7 @@ def test_financial_decision_support_time_horizon(monkeypatch):
 def test_financial_decision_support_ume_error(monkeypatch):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             raise requests.HTTPError("boom")
@@ -234,7 +234,7 @@ def test_financial_decision_support_ume_error(monkeypatch):
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -262,7 +262,7 @@ def test_financial_decision_support_ume_error(monkeypatch):
 def test_financial_decision_support_engine_failure(monkeypatch):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             return DummyResponse({"nodes": []})
@@ -309,7 +309,7 @@ def test_financial_decision_support_engine_failure(monkeypatch):
             (task_name, stage, status, reason, output, partial, user_id, group_id)
         )
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -365,7 +365,7 @@ def test_financial_decision_support_engine_failure(monkeypatch):
 def test_financial_decision_support_persistence_failure(monkeypatch):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         if method == "GET":
             return DummyResponse({"nodes": []})
@@ -413,7 +413,7 @@ def test_financial_decision_support_persistence_failure(monkeypatch):
             (task_name, stage, status, reason, output, partial, user_id, group_id)
         )
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -466,7 +466,7 @@ def test_financial_decision_support_persistence_failure(monkeypatch):
 def test_financial_decision_support_missing_fields(monkeypatch, payload, missing):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         return DummyResponse({})
 
@@ -485,7 +485,7 @@ def test_financial_decision_support_missing_fields(monkeypatch, payload, missing
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -527,7 +527,7 @@ def test_financial_decision_support_missing_fields(monkeypatch, payload, missing
 def test_financial_decision_support_negative_values(monkeypatch, payload, field):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         return DummyResponse({})
 
@@ -546,7 +546,7 @@ def test_financial_decision_support_negative_values(monkeypatch, payload, field)
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)
@@ -586,7 +586,7 @@ def test_financial_decision_support_negative_values(monkeypatch, payload, field)
 def test_financial_decision_support_invalid_values(monkeypatch, payload, field):
     calls = []
 
-    def fake_request(method, url, timeout, **kwargs):
+    async def fake_request(method, url, timeout, **kwargs):
         calls.append((method, url, kwargs))
         return DummyResponse({})
 
@@ -605,7 +605,7 @@ def test_financial_decision_support_invalid_values(monkeypatch, payload, field):
     def fake_audit_log(task_name, stage, status, *, reason=None, output=None, user_id=None, group_id=None, **_):
         audit_logs.append((task_name, stage, status, reason, output, user_id, group_id))
 
-    monkeypatch.setattr(fds, "request_with_retry", fake_request)
+    monkeypatch.setattr(fds, "request_with_retry_async", fake_request)
     monkeypatch.setattr(fds, "emit_stage_update_event", fake_emit)
     monkeypatch.setattr(fds, "dispatch", fake_dispatch)
     monkeypatch.setattr(fds, "emit_audit_log", fake_audit_log)

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,6 +1,8 @@
+import asyncio
 import pytest
 import requests
-from task_cascadence.http_utils import request_with_retry
+import httpx
+from task_cascadence.http_utils import request_with_retry, request_with_retry_async
 import time
 
 
@@ -46,3 +48,59 @@ def test_request_with_retry_timeout(monkeypatch):
     with pytest.raises(requests.Timeout):
         request_with_retry("GET", "http://x", timeout=0.5, retries=2, backoff_factor=0, session=session)
     assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_request_with_retry_async_success(monkeypatch):
+    class FakeClient:
+        def __init__(self):
+            self.calls = 0
+
+        async def request(self, method, url, timeout=0, **kwargs):
+            self.calls += 1
+            assert timeout == 1.0
+            if self.calls < 3:
+                raise httpx.HTTPError("boom")
+            return DummyResponse()
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(s):
+        sleeps.append(s)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    client = FakeClient()
+    resp = await request_with_retry_async(
+        "GET",
+        "http://x",
+        timeout=1.0,
+        retries=3,
+        backoff_factor=0.1,
+        client=client,
+    )
+    assert isinstance(resp, DummyResponse)
+    assert client.calls == 3
+    assert len(sleeps) == 2
+
+
+@pytest.mark.asyncio
+async def test_request_with_retry_async_timeout(monkeypatch):
+    class FakeClient:
+        def __init__(self):
+            self.calls = 0
+
+        async def request(self, method, url, timeout=0, **kwargs):
+            self.calls += 1
+            assert timeout == 0.5
+            raise httpx.TimeoutException("nope")
+
+    async def fake_sleep(_):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    client = FakeClient()
+    with pytest.raises(httpx.TimeoutException):
+        await request_with_retry_async(
+            "GET", "http://x", timeout=0.5, retries=2, backoff_factor=0, client=client
+        )
+    assert client.calls == 2


### PR DESCRIPTION
## Summary
- add asynchronous `request_with_retry_async`
- convert financial decision support workflow to async HTTP calls
- update tests for async request handling

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03cb5876883268479a54db4dac637