### PR TITLE
test: cover edge persistence failure

### DIFF
--- a/tests/test_calendar_persistence_error.py
+++ b/tests/test_calendar_persistence_error.py
@@ -45,7 +45,9 @@ def test_calendar_edge_persistence_error(monkeypatch):
             return DummyResponse({"allowed": True})
         if url.endswith("/v1/calendar/events"):
             return DummyResponse({"id": "evt1"})
-        raise RuntimeError("edge boom")
+        if url.endswith("/v1/calendar/edges"):
+            raise RuntimeError("edge boom")
+        raise AssertionError(f"unexpected request: {method} {url}")
 
     audit_logs: list[tuple[str, str, str, str | None]] = []
 


### PR DESCRIPTION
## Summary
- exercise calendar edge creation failure path
- ensure persistence audit log captures edge failure reason

## Testing
- `ruff check tests/test_calendar_persistence_error.py`
- `pytest tests/test_calendar_persistence_error.py`


------
https://chatgpt.com/codex/tasks/task_e_68c05279ac20832691497c765c02d066