### PR TITLE
docs: add cron schedule examples

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,6 +42,23 @@ This guide walks you through running a simple task pipeline locally using TaskCa
 
 3. To enable Temporal integration, install the `temporalio` package and start a Temporal server via Docker. Then set the `TEMPORAL_HOST` and `TEMPORAL_PORT` environment variables before running your pipeline.
 
+4. Schedule the task to run automatically:
+   1. Create a `schedules.yml` file:
+      ```yaml
+      Demo:
+        expr: "*/5 * * * *"
+        user_id: alice
+        group_id: engineering
+      ```
+   2. Load the configuration with the CLI:
+      ```bash
+      task load-schedules schedules.yml
+      ```
+   Cron expressions follow the `minute hour day-of-month month day-of-week` pattern.
+   The example above runs the `Demo` task every five minutes with the provided
+   user and group identifiers. Use values such as `0 9 * * MON-FRI` for weekday
+   runs or `30 2 1 * *` for a monthly schedule.
+
 ## More information
 
 Refer to the full documentation in `README.md` for details about pipeline configuration, plugins, and advanced features.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,45 @@ $ task webhook [--host HOST] [--port PORT]  # start webhook server
 $ task watch-plugins DIR # reload plugins on changes in DIR
 ```
 
+### Cron schedules and YAML configuration
+
+Cron expressions use the standard five-field format interpreted by
+APScheduler: ``minute hour day-of-month month day-of-week``. Wildcards
+(``*``), step values (``*/5``), ranges (``1-5``), and named weekdays or
+months (``MON-FRI``, ``JAN``) are all accepted. For example:
+
+- ``*/5 * * * *`` – run every five minutes.
+- ``0 9 * * MON-FRI`` – run at 09:00 Monday through Friday.
+- ``30 2 1 * *`` – run at 02:30 on the first day of each month.
+
+Schedules can be loaded in bulk from a YAML file. Each key should match the
+task's class name or registered identifier. Values may be a bare cron string
+or a mapping with extra metadata:
+
+```yaml
+# schedules.yml
+ExampleTask: "*/5 * * * *"
+
+NightlySummary:
+  expr: "0 1 * * *"
+  user_id: analytics@example.com
+  group_id: insights
+  recurrence:
+    note: Nightly ETL refresh
+
+CalendarDrivenTask:
+  calendar_event:
+    node: /calendar/nodes/team-sync
+    poll: 600  # refresh every 10 minutes
+  user_id: manager@example.com
+  group_id: leadership
+```
+
+Use ``task load-schedules schedules.yml`` to register every entry. ``user_id``
+and ``group_id`` values are hashed on disk automatically. When a
+``calendar_event`` is supplied the scheduler pulls recurrence details from the
+referenced UME node and keeps them current.
+
 Global options allow metrics and UME transport configuration:
 
 ```bash


### PR DESCRIPTION
## Summary
- document cron expression syntax for the scheduler
- add YAML schedule examples including metadata and calendar-driven tasks
- extend the quickstart with steps for loading schedules via the CLI

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cace49b3288326a9dbbc92b089a300