### PR TITLE
Preserve scheduler user context across restarts

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_cli_schedule_creates_entry(monkeypatch, tmp_path):
 
     data = yaml.safe_load((tmp_path / "sched.yml").read_text())
     assert data["ExampleTask"]["expr"] == "0 12 * * *"
-    assert data["ExampleTask"]["user_id"] == _hash_user_id("alice")
+    assert data["ExampleTask"]["user_hash"] == _hash_user_id("alice")
 
 
 def test_cli_schedule_user_id(monkeypatch, tmp_path):
@@ -145,7 +145,7 @@ def test_cli_schedule_user_id(monkeypatch, tmp_path):
 
     data = yaml.safe_load((tmp_path / "sched.yml").read_text())
     assert data["ExampleTask"]["expr"] == "0 12 * * *"
-    assert data["ExampleTask"]["user_id"] == _hash_user_id("charlie")
+    assert data["ExampleTask"]["user_hash"] == _hash_user_id("charlie")
 
 
 def test_cli_schedule_unknown_task(monkeypatch):

--- a/tests/test_poll_calendar_event.py
+++ b/tests/test_poll_calendar_event.py
@@ -32,5 +32,5 @@ def test_poll_calendar_event(monkeypatch, tmp_path):
     assert entry["calendar_event"] == {"node": "node42", "poll": 1}
     from task_cascadence.ume import _hash_user_id
 
-    assert entry["user_id"] == _hash_user_id("alice")
-    assert entry["group_id"] == _hash_user_id("engineering")
+    assert entry["user_hash"] == _hash_user_id("alice")
+    assert entry["group_hash"] == _hash_user_id("engineering")

--- a/tests/test_schedule_from_event.py
+++ b/tests/test_schedule_from_event.py
@@ -24,8 +24,8 @@ def test_schedule_from_event_registers_metadata(tmp_path):
     assert entry["recurrence"] == {"cron": "*/5 * * * *"}
     from task_cascadence.ume import _hash_user_id
 
-    assert entry["user_id"] == _hash_user_id("alice")
-    assert entry["group_id"] == _hash_user_id("engineering")
+    assert entry["user_hash"] == _hash_user_id("alice")
+    assert entry["group_hash"] == _hash_user_id("engineering")
 
 
 def test_yaml_recurrence_loaded(tmp_path):

--- a/tests/test_scheduler_calendar_hash.py
+++ b/tests/test_scheduler_calendar_hash.py
@@ -37,8 +37,8 @@ def test_register_task_hashes_group_id(tmp_path):
     task = DummyTask()
     sched.register_task(task, "* * * * *", user_id="alice", group_id="engineering")
     entry = sched.schedules["DummyTask"]
-    assert entry["group_id"] == expected_hash("engineering")
+    assert entry["group_hash"] == expected_hash("engineering")
     import yaml
 
     persisted = yaml.safe_load((tmp_path / "s.yml").read_text())
-    assert persisted["DummyTask"]["group_id"] == expected_hash("engineering")
+    assert persisted["DummyTask"]["group_hash"] == expected_hash("engineering")

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -101,11 +101,11 @@ def test_schedule_from_calendar_event(tmp_path):
     assert entry["recurrence"] == {"cron": "*/2 * * * *"}
     expected_user = expected_hash("alice")
     expected_group = expected_hash("engineering")
-    assert entry["user_id"] == expected_user
-    assert entry["group_id"] == expected_group
+    assert entry["user_hash"] == expected_user
+    assert entry["group_hash"] == expected_group
     persisted = yaml.safe_load((tmp_path / "sched.yml").read_text())
-    assert persisted["DummyTask"]["user_id"] == expected_user
-    assert persisted["DummyTask"]["group_id"] == expected_group
+    assert persisted["DummyTask"]["user_hash"] == expected_user
+    assert persisted["DummyTask"]["group_hash"] == expected_group
     assert persisted["DummyTask"]["recurrence"] == {"cron": "*/2 * * * *"}
 
 
@@ -122,11 +122,11 @@ def test_loads_plain_identifiers_and_rewrites(tmp_path):
     sched = CronScheduler(timezone="UTC", storage_path=sched_file)
     expected_user = expected_hash("alice")
     expected_group = expected_hash("engineering")
-    assert sched.schedules["DummyTask"]["user_id"] == expected_user
-    assert sched.schedules["DummyTask"]["group_id"] == expected_group
+    assert sched.schedules["DummyTask"]["user_hash"] == expected_user
+    assert sched.schedules["DummyTask"]["group_hash"] == expected_group
     persisted = yaml.safe_load(sched_file.read_text())
-    assert persisted["DummyTask"]["user_id"] == expected_user
-    assert persisted["DummyTask"]["group_id"] == expected_group
+    assert persisted["DummyTask"]["user_hash"] == expected_user
+    assert persisted["DummyTask"]["group_hash"] == expected_group
 
 
 def test_yaml_calendar_event_daily(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- store plaintext task context in memory while persisting hashed user and group identifiers for cron schedules
- load saved context on scheduler startup so restored jobs invoke tasks with the original user and group identifiers
- update scheduler-related tests to reflect the new storage format and cover restart behaviour

## Testing
- `pytest tests/test_scheduler.py tests/test_scheduler_calendar_hash.py tests/test_poll_calendar_event.py tests/test_schedule_from_event.py tests/test_yaml_schedule.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd77f89df88326ba11f1510bc08a57