### PR TITLE
Ensure calendar workflow tests import asyncio early

### DIFF
--- a/tests/test_calendar_workflow.py
+++ b/tests/test_calendar_workflow.py
@@ -2,11 +2,11 @@
 # Tests for calendar event creation workflow
 
 import asyncio
-import pytest
-
 import sys
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 


### PR DESCRIPTION
## Summary
- group the standard library imports at the top of `tests/test_calendar_workflow.py`
- keep `pytest` separated as a third-party dependency import for clarity

## Testing
- pytest tests/test_calendar_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a029204883269c01dc7c3957a8fd