### PR TITLE
Fix missing imports in scheduler calendar hash tests

### DIFF
--- a/tests/test_scheduler_calendar_hash.py
+++ b/tests/test_scheduler_calendar_hash.py
@@ -1,5 +1,7 @@
+import yaml
+
+from task_cascadence import scheduler
 from task_cascadence.scheduler import CronScheduler
-import task_cascadence.scheduler as scheduler
 from task_cascadence.ume import _hash_user_id
 
 


### PR DESCRIPTION
## Summary
- add the missing yaml and scheduler imports used by the scheduler calendar hash tests

## Testing
- pytest tests/test_scheduler_calendar_hash.py

------
https://chatgpt.com/codex/tasks/task_e_68dd127a1e848326836a3ba39e23d4b0