### PR TITLE
Reorder finance explainability test imports

### DIFF
--- a/tests/test_finance_explain.py
+++ b/tests/test_finance_explain.py
@@ -1,6 +1,6 @@
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.modules["task_cascadence.workflows.calendar_event_creation"] = types.ModuleType(


### PR DESCRIPTION
## Summary
- reorder the finance explainability test imports so the required sys and pathlib modules load at module import time

## Testing
- pytest -o addopts= tests/test_finance_explain.py

------
https://chatgpt.com/codex/tasks/task_e_68dd127951d8832699c7ad2d6d2be51f