### PR TITLE
Ensure schedule tests import yaml

### DIFF
--- a/tests/test_schedule_from_event.py
+++ b/tests/test_schedule_from_event.py
@@ -1,5 +1,5 @@
-import yaml
 import pytest
+import yaml
 from apscheduler.triggers.cron import CronTrigger
 from task_cascadence.scheduler import CronScheduler
 


### PR DESCRIPTION
## Summary
- adjust the imports in the schedule-from-event tests so that `yaml` is imported explicitly at the top of the file

## Testing
- pytest tests/test_schedule_from_event.py

------
https://chatgpt.com/codex/tasks/task_e_68dd214eb5d88326a252187e39aa3353