### PR TITLE
Refactor pipeline registry to use run identifiers

### DIFF
--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -231,7 +231,7 @@ class BaseScheduler:
                         for attr in ("intake", "research", "plan", "verify")
                     ):
                         pipeline = TaskPipeline(task)
-                        add_pipeline(name, pipeline)
+                        add_pipeline(name, run_id, pipeline)
                         try:
                             result = pipeline.run(user_id=uid, group_id=group_id)
                             if inspect.isawaitable(result):
@@ -239,7 +239,7 @@ class BaseScheduler:
                                     cast(Coroutine[Any, Any, Any], result)
                                 )
                         finally:
-                            remove_pipeline(name)
+                            remove_pipeline(run_id)
                     else:
                         task.user_id = uid
                         task.group_id = group_id

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -5,6 +5,8 @@ from task_cascadence.pipeline_registry import (
     remove_pipeline,
     list_pipelines,
     attach_pipeline_context,
+    get_pipeline,
+    get_latest_pipeline_for_task,
 )
 from task_cascadence.orchestrator import TaskPipeline
 from task_cascadence.plugins import ExampleTask
@@ -18,10 +20,11 @@ def test_thread_safe_registry():
     def add_remove_worker(worker_id: int) -> None:
         # Add and remove multiple pipelines
         for i in range(100):
-            name = f"p{worker_id}_{i}"
-            add_pipeline(name, pipeline)
+            task_name = f"task{worker_id}"
+            run_id = f"{task_name}_run_{i}"
+            add_pipeline(task_name, run_id, pipeline)
             time.sleep(0.001)
-            remove_pipeline(name)
+            remove_pipeline(run_id)
         if worker_id == 0:
             stop_event.set()
 
@@ -72,10 +75,11 @@ def test_attach_pipeline_context_exposes_pipeline(monkeypatch):
             return "ok"
 
     pipeline = TaskPipeline(SimpleTask())
-    add_pipeline("demo", pipeline)
+    run_id = "run-demo"
+    add_pipeline("demo", run_id, pipeline)
     try:
         assert attach_pipeline_context(
-            "demo", {"payload": 1}, user_id="carol", group_id="g"
+            run_id, {"payload": 1}, user_id="carol", group_id="g"
         )
         result = pipeline.run(user_id="carol", group_id="g")
         assert result == "ok"
@@ -83,6 +87,30 @@ def test_attach_pipeline_context_exposes_pipeline(monkeypatch):
         assert stages.count("context_attached") == 1
         assert ("context_attached", "{'payload': 1}") in audits
     finally:
-        remove_pipeline("demo")
+        remove_pipeline(run_id)
 
     assert attach_pipeline_context("missing", "value") is False
+
+
+def test_pipeline_lookup_helpers():
+    class DummyTask:
+        def run(self):
+            return "done"
+
+    first_pipeline = TaskPipeline(DummyTask())
+    second_pipeline = TaskPipeline(DummyTask())
+
+    add_pipeline("demo", "run-1", first_pipeline)
+    add_pipeline("demo", "run-2", second_pipeline)
+
+    try:
+        assert get_pipeline("run-1") is first_pipeline
+        assert get_latest_pipeline_for_task("demo") is second_pipeline
+        # Removing the latest should cause the previous run to be returned next
+        remove_pipeline("run-2")
+        assert get_latest_pipeline_for_task("demo") is first_pipeline
+        # Fallback by task name should succeed while the first pipeline remains
+        assert attach_pipeline_context("demo", {"payload": 2}) is True
+    finally:
+        remove_pipeline("run-1")
+

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -272,10 +272,10 @@ def test_yaml_calendar_event_multiple_recurrences(tmp_path, monkeypatch):
 
     pr_mod = types.ModuleType("task_cascadence.pipeline_registry")
 
-    def add_pipeline(name, pipeline):  # pragma: no cover - stub
+    def add_pipeline(task_name, run_id, pipeline):  # pragma: no cover - stub
         pass
 
-    def remove_pipeline(name):  # pragma: no cover - stub
+    def remove_pipeline(run_id):  # pragma: no cover - stub
         pass
 
     pr_mod.add_pipeline = add_pipeline


### PR DESCRIPTION
## Summary
- refactor the pipeline registry to index pipelines by run identifier while keeping a task-name index and helper APIs
- update scheduler logic and supporting tests to register/remove pipelines with the generated run IDs
- expand registry tests to cover helper lookups and task-name fallbacks

## Testing
- pytest *(fails: pytest-cov not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfed7afda48326824d3c500053c481