### PR TITLE
Update pipeline signaling to use run identifiers

### DIFF
--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -118,12 +118,13 @@ def run_task(
             user_id=user_id,
             group_id=group_id,
         )
-        get_default_scheduler().run_task(
+        execution = get_default_scheduler().run_task_with_metadata(
             name,
             use_temporal=temporal,
             user_id=user_id,
             group_id=group_id,
         )
+        typer.echo(f"run-id\t{execution.run_id}")
         emit_stage_update_event(
             name,
             "finish",
@@ -162,14 +163,16 @@ def run_task_async(
             user_id=user_id,
             group_id=group_id,
         )
-        result = get_default_scheduler().run_task(
+        execution = get_default_scheduler().run_task_with_metadata(
             name,
             use_temporal=temporal,
             user_id=user_id,
             group_id=group_id,
         )
+        result = execution.result
         if inspect.isawaitable(result):
             result = run_coroutine(cast(Coroutine[Any, Any, Any], result))
+        typer.echo(f"run-id\t{execution.run_id}")
         emit_stage_update_event(
             name,
             "finish",

--- a/task_cascadence/pipeline_registry.py
+++ b/task_cascadence/pipeline_registry.py
@@ -7,8 +7,6 @@ from typing import Any, Dict, Optional
 
 from .orchestrator import TaskPipeline
 
-# Running pipelines keyed by task name and run identifier
-_running_pipelines: Dict[str, Dict[str, TaskPipeline]] = {}
 # Running pipelines keyed by run/job identifier
 _running_pipelines: Dict[str, TaskPipeline] = {}
 # Mapping of run/job identifier back to originating task name
@@ -19,97 +17,87 @@ _task_run_index: Dict[str, list[str]] = {}
 _registry_lock = Lock()
 
 
-def add_pipeline(name: str, run_id: str, pipeline: TaskPipeline) -> None:
-    """Register *pipeline* under *name* and *run_id*."""
-
-    with _registry_lock:
-        pipelines = _running_pipelines.setdefault(name, {})
-        pipelines[run_id] = pipeline
-
 def add_pipeline(task_name: str, run_id: str, pipeline: TaskPipeline) -> None:
     """Register *pipeline* for *task_name* under the unique *run_id*."""
 
     with _registry_lock:
         _running_pipelines[run_id] = pipeline
         _pipeline_tasks[run_id] = task_name
-        runs_for_task = _task_run_index.setdefault(task_name, [])
-        runs_for_task.append(run_id)
+        _task_run_index.setdefault(task_name, []).append(run_id)
 
-def remove_pipeline(name: str, run_id: str) -> None:
-    """Remove the pipeline registered under *name*/*run_id* if present."""
 
-    with _registry_lock:
-        pipelines = _running_pipelines.get(name)
-        if not pipelines:
-            return
-        pipelines.pop(run_id, None)
-        if not pipelines:
-            _running_pipelines.pop(name, None)
-def remove_pipeline(run_id: str) -> None:
+def remove_pipeline(run_id: str, task_name: str | None = None) -> None:
     """Remove the pipeline registered under *run_id* if present."""
 
     with _registry_lock:
-        task_name = _pipeline_tasks.pop(run_id, None)
         _running_pipelines.pop(run_id, None)
-        if task_name is not None:
-            runs_for_task = _task_run_index.get(task_name)
-            if runs_for_task is not None:
-                try:
-                    runs_for_task.remove(run_id)
-                except ValueError:  # pragma: no cover - defensive cleanup
-                    pass
-                if not runs_for_task:
-                    _task_run_index.pop(task_name, None)
+        resolved_task = task_name or _pipeline_tasks.pop(run_id, None)
+        if resolved_task is None:
+            return
+        runs_for_task = _task_run_index.get(resolved_task)
+        if not runs_for_task:
+            return
+        try:
+            runs_for_task.remove(run_id)
+        except ValueError:  # pragma: no cover - defensive cleanup
+            pass
+        if not runs_for_task:
+            _task_run_index.pop(resolved_task, None)
 
 
-def get_pipeline(run_id: str) -> Optional[TaskPipeline]:
-    """Return the pipeline registered under *run_id* if running."""
+def _clean_latest_for_task(task_name: str) -> Optional[TaskPipeline]:
+    """Return the latest pipeline for *task_name* while pruning stale entries."""
+
+    run_ids = _task_run_index.get(task_name)
+    if not run_ids:
+        return None
+
+    for index in range(len(run_ids) - 1, -1, -1):
+        run_id = run_ids[index]
+        pipeline = _running_pipelines.get(run_id)
+        if pipeline is not None:
+            return pipeline
+        # Stale identifier encountered; remove it before continuing.
+        del run_ids[index]
+    if not run_ids:
+        _task_run_index.pop(task_name, None)
+    return None
+
+
+def get_pipeline(identifier: str, *, run_id: str | None = None) -> Optional[TaskPipeline]:
+    """Return the pipeline registered as *identifier*.
+
+    ``identifier`` is treated as a run identifier first. For backward
+    compatibility, when no pipeline exists for the identifier it falls back to
+    the most recent pipeline registered for the task of the same name. A
+    specific *run_id* can be provided to bypass the lookup heuristic.
+    """
 
     with _registry_lock:
-        return _running_pipelines.get(run_id)
+        if run_id is not None:
+            pipeline = _running_pipelines.get(run_id)
+            if pipeline is not None:
+                return pipeline
 
-def get_pipeline(name: str, run_id: Optional[str] = None) -> Optional[TaskPipeline]:
-    """Return the pipeline registered as *name* (optionally filtered by *run_id*)."""
+        pipeline = _running_pipelines.get(identifier)
+        if pipeline is not None:
+            return pipeline
+
+        return _clean_latest_for_task(identifier)
+
 
 def get_latest_pipeline_for_task(task_name: str) -> Optional[TaskPipeline]:
     """Return the most recently registered pipeline for *task_name* if running."""
 
     with _registry_lock:
-        run_ids = _task_run_index.get(task_name)
-        if not run_ids:
-            return None
-        # The list is maintained oldest -> newest, so walk backwards to find the
-        # first run id that is still registered. Defensive cleanup ensures stale
-        # identifiers are removed if encountered.
-        for index in range(len(run_ids) - 1, -1, -1):
-            run_id = run_ids[index]
-            pipeline = _running_pipelines.get(run_id)
-            if pipeline is not None:
-                return pipeline
-            # Stale identifier encountered; remove it before continuing.
-            del run_ids[index]
-        if not run_ids:
-            _task_run_index.pop(task_name, None)
-        return None
-
-    with _registry_lock:
-        pipelines = _running_pipelines.get(name)
-        if not pipelines:
-            return None
-        if run_id is not None:
-            return pipelines.get(run_id)
-        if len(pipelines) == 1:
-            return next(iter(pipelines.values()))
-        return None
+        return _clean_latest_for_task(task_name)
 
 
-def list_pipelines() -> Dict[str, Dict[str, TaskPipeline]]:
-    """Return a copy of the currently registered pipelines."""
 def list_pipelines() -> Dict[str, TaskPipeline]:
     """Return a copy of the currently registered pipelines keyed by run id."""
 
     with _registry_lock:
-        return {name: dict(pipes) for name, pipes in _running_pipelines.items()}
+        return dict(_running_pipelines)
 
 
 def attach_pipeline_context(
@@ -118,7 +106,6 @@ def attach_pipeline_context(
     *,
     user_id: str | None = None,
     group_id: str | None = None,
-    run_id: str | None = None,
 ) -> bool:
     """Attach *context* to the running pipeline identified by *run_id_or_task*.
 
@@ -128,11 +115,18 @@ def attach_pipeline_context(
     Returns ``True`` when a pipeline was found and context enqueued.
     """
 
-    pipeline = get_pipeline(name, run_id=run_id)
     pipeline = get_pipeline(run_id_or_task)
     if pipeline is None:
-        pipeline = get_latest_pipeline_for_task(run_id_or_task)
-        if pipeline is None:
-            return False
+        return False
     pipeline.attach_context(context, user_id=user_id, group_id=group_id)
     return True
+
+
+__all__ = [
+    "add_pipeline",
+    "remove_pipeline",
+    "get_pipeline",
+    "get_latest_pipeline_for_task",
+    "list_pipelines",
+    "attach_pipeline_context",
+]

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -271,8 +271,7 @@ class BaseScheduler:
                                     cast(Coroutine[Any, Any, Any], result)
                                 )
                         finally:
-                            remove_pipeline(name, run_id)
-                            remove_pipeline(run_id)
+                            remove_pipeline(run_id, task_name=name)
                     else:
                         task.user_id = uid
                         task.group_id = group_id

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -6,7 +6,8 @@ from task_cascadence.api import app
 from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.stage_store import StageStore
-from task_cascadence.pipeline_registry import get_pipeline
+from task_cascadence.pipeline_registry import add_pipeline, get_pipeline, remove_pipeline
+from task_cascadence.orchestrator import TaskPipeline
 import threading
 import time
 
@@ -174,8 +175,13 @@ def test_api_context_signal(monkeypatch, tmp_path):
 
     assert task.research_started.wait(timeout=1)
 
+    pipeline = get_pipeline("contextsignal")
+    assert pipeline is not None
+    run_id = pipeline.current_run_id
+    assert run_id is not None
+
     resp = client.post(
-        "/tasks/contextsignal/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "context", "value": {"note": "hi"}},
     )
@@ -203,3 +209,105 @@ def test_api_context_signal(monkeypatch, tmp_path):
         and event.get("status") == "consumed"
         for event in audit_events
     )
+
+    resp = client.post(
+        f"/tasks/{run_id}/signal",
+        headers={"X-User-ID": "alice", "X-Group-ID": "team"},
+        json={"kind": "context", "value": {"note": "later"}},
+    )
+    assert resp.status_code == 404
+
+
+def test_parallel_context_signals_route_to_matching_pipeline(monkeypatch):
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_stage_update_event", lambda *a, **k: None)
+    monkeypatch.setattr("task_cascadence.orchestrator.emit_audit_log", lambda *a, **k: None)
+
+    class ParallelContextTask(ExampleTask):
+        name = "parallel-context"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.research_ready = threading.Event()
+            self.allow_plan = threading.Event()
+            self.plan_contexts: list[list[dict[str, Any]]] = []
+            self.run_contexts: list[list[dict[str, Any]]] = []
+
+        def intake(self) -> None:
+            pass
+
+        def research(self) -> None:
+            self.research_ready.set()
+            if not self.allow_plan.wait(timeout=1):
+                raise AssertionError("research did not resume")
+
+        def plan(self) -> dict[str, Any]:
+            snapshot = list(self.context)
+            self.plan_contexts.append(snapshot)
+            return snapshot[-1] if snapshot else {}
+
+        def run(self, plan_result: dict[str, Any]) -> dict[str, Any]:
+            self.run_contexts.append(list(self.context))
+            return plan_result
+
+    task_one = ParallelContextTask()
+    task_two = ParallelContextTask()
+
+    pipeline_one = TaskPipeline(task_one)
+    pipeline_two = TaskPipeline(task_two)
+
+    run_one = "run-one"
+    run_two = "run-two"
+    pipeline_one.current_run_id = run_one
+    pipeline_two.current_run_id = run_two
+
+    add_pipeline("parallel-context", run_one, pipeline_one)
+    add_pipeline("parallel-context", run_two, pipeline_two)
+
+    client = TestClient(app)
+
+    thread_one = threading.Thread(
+        target=lambda: pipeline_one.run(user_id="alice", group_id="team"), daemon=True
+    )
+    thread_two = threading.Thread(
+        target=lambda: pipeline_two.run(user_id="bob", group_id="ops"), daemon=True
+    )
+
+    thread_one.start()
+    thread_two.start()
+
+    try:
+        assert task_one.research_ready.wait(timeout=1)
+        assert task_two.research_ready.wait(timeout=1)
+
+        resp_one = client.post(
+            f"/tasks/{run_one}/signal",
+            headers={"X-User-ID": "alice", "X-Group-ID": "team"},
+            json={"kind": "context", "value": {"note": "one"}},
+        )
+        resp_two = client.post(
+            f"/tasks/{run_two}/signal",
+            headers={"X-User-ID": "bob", "X-Group-ID": "ops"},
+            json={"kind": "context", "value": {"note": "two"}},
+        )
+
+        assert resp_one.status_code == 202
+        assert resp_two.status_code == 202
+
+        task_one.allow_plan.set()
+        task_two.allow_plan.set()
+
+        thread_one.join(timeout=2)
+        thread_two.join(timeout=2)
+
+        assert not thread_one.is_alive()
+        assert not thread_two.is_alive()
+
+        assert task_one.plan_contexts == [[{"note": "one"}]]
+        assert task_two.plan_contexts == [[{"note": "two"}]]
+        assert task_one.run_contexts == [[{"note": "one"}]]
+        assert task_two.run_contexts == [[{"note": "two"}]]
+    finally:
+        remove_pipeline(run_one, task_name="parallel-context")
+        remove_pipeline(run_two, task_name="parallel-context")

--- a/tests/test_context_signal.py
+++ b/tests/test_context_signal.py
@@ -196,9 +196,11 @@ def test_api_context_signal_delivery(monkeypatch: pytest.MonkeyPatch, tmp_path) 
     assert task.research_started.wait(timeout=1)
     pipeline = get_pipeline("api-context")
     assert pipeline is not None
+    run_id = pipeline.current_run_id
+    assert run_id is not None
 
     resp = client.post(
-        "/tasks/api-context/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "context", "value": {"note": "hello"}},
     )
@@ -229,8 +231,13 @@ def test_api_context_signal_rejects_unsupported_kind(
 
     assert task.research_started.wait(timeout=1)
 
+    pipeline = get_pipeline("api-context")
+    assert pipeline is not None
+    run_id = pipeline.current_run_id
+    assert run_id is not None
+
     resp = client.post(
-        "/tasks/api-context/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "unknown", "value": {}},
     )
@@ -252,7 +259,7 @@ def test_api_context_signal_rejects_unsupported_kind(
 def test_api_context_signal_missing_headers(headers, expected) -> None:
     client = TestClient(app)
     resp = client.post(
-        "/tasks/example/signal",
+        "/tasks/run-123/signal",
         headers=headers,
         json={"kind": "context", "value": {}},
     )

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -272,14 +272,10 @@ def test_yaml_calendar_event_multiple_recurrences(tmp_path, monkeypatch):
 
     pr_mod = types.ModuleType("task_cascadence.pipeline_registry")
 
-    def add_pipeline(name, run_id, pipeline):  # pragma: no cover - stub
-        pass
-
-    def remove_pipeline(name, run_id):  # pragma: no cover - stub
     def add_pipeline(task_name, run_id, pipeline):  # pragma: no cover - stub
         pass
 
-    def remove_pipeline(run_id):  # pragma: no cover - stub
+    def remove_pipeline(run_id, task_name=None):  # pragma: no cover - stub
         pass
 
     pr_mod.add_pipeline = add_pipeline


### PR DESCRIPTION
## Summary
- return run identifiers from the task run APIs and update the signal endpoint to target runs by job id
- rework the pipeline registry to index pipelines by run id and adjust the scheduler/CLI to surface the identifier
- expand API and CLI tests to cover multi-run signaling, run id propagation, and CLI-driven context delivery

## Testing
- pytest --override-ini addopts="" tests/test_api.py tests/test_api_pipeline.py tests/test_context_signal.py tests/test_cli.py tests/test_pipeline_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d9a51fb4832693b99c7d11c99a87