### PR TITLE
Expose run IDs in task APIs and align job controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ curl -X POST http://localhost:8000/tasks/example/run \
      -H "X-Group-ID: engineering"
 ```
 
+The response includes the unique run identifier alongside the task output, e.g.
+``{"run_id": "20240101T120000Z", "result": "ok"}``.
+
 In code, pass the same information via ``user_id`` and ``group_id`` arguments:
 
 ```python
@@ -302,10 +305,11 @@ Example usage with ``httpx``:
 import httpx
 
 tasks = httpx.get("http://localhost:8000/tasks").json()
-httpx.post(
+run = httpx.post(
     "http://localhost:8000/tasks/example/run",
     headers={"X-User-ID": "bob", "X-Group-ID": "engineering"},
-)
+).json()
+print(f"Started job {run['run_id']} with result {run['result']}")
 
 # capture a task definition from another machine
 httpx.post(

--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -103,8 +103,9 @@ def run_task(
             "user_id": user_id,
             "group_id": group_id,
         }
-        result = sched.run_task(name, **kwargs)
-        return {"result": result}
+        metadata = sched.run_task_with_metadata(name, **kwargs)
+        result = metadata.result
+        return {"run_id": metadata.run_id, "result": result}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -127,10 +128,11 @@ async def run_task_async(
             "user_id": user_id,
             "group_id": group_id,
         }
-        result = sched.run_task(name, **kwargs)
+        metadata = sched.run_task_with_metadata(name, **kwargs)
+        result = metadata.result
         if inspect.isawaitable(result):
             result = await result
-        return {"result": result}
+        return {"run_id": metadata.run_id, "result": result}
     except Exception as exc:  # pragma: no cover - passthrough
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -182,13 +184,20 @@ def disable_task(
 @app.post("/tasks/{name}/pause")
 def pause_task(
     name: str,
+    job_id: str | None = None,
     user_id: str = Depends(get_user_id),
     group_id: str = Depends(get_group_id),
 ):
     """Pause ``name`` so it temporarily stops running."""
     sched = get_default_scheduler()
     try:
-        pipeline = get_pipeline(name)
+        pipeline = None
+        if job_id is not None:
+            pipeline = get_pipeline(name, run_id=job_id)
+            if pipeline is None:
+                raise HTTPException(404, "pipeline not running")
+        else:
+            pipeline = get_pipeline(name)
         if pipeline:
             if user_id is None:
                 raise HTTPException(400, "user_id is required")
@@ -205,13 +214,20 @@ def pause_task(
 @app.post("/tasks/{name}/resume")
 def resume_task(
     name: str,
+    job_id: str | None = None,
     user_id: str = Depends(get_user_id),
     group_id: str = Depends(get_group_id),
 ):
     """Resume a previously paused task."""
     sched = get_default_scheduler()
     try:
-        pipeline = get_pipeline(name)
+        pipeline = None
+        if job_id is not None:
+            pipeline = get_pipeline(name, run_id=job_id)
+            if pipeline is None:
+                raise HTTPException(404, "pipeline not running")
+        else:
+            pipeline = get_pipeline(name)
         if pipeline:
             if user_id is None:
                 raise HTTPException(400, "user_id is required")
@@ -225,16 +241,16 @@ def resume_task(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@app.post("/tasks/{name}/signal")
+@app.post("/tasks/{job_id}/signal")
 def signal_task(
-    name: str,
+    job_id: str,
     payload: SignalPayload,
     user_id: str = Depends(get_user_id),
     group_id: str = Depends(get_group_id),
 ):
     """Deliver a signal to a running pipeline."""
 
-    pipeline = get_pipeline(name)
+    pipeline = get_pipeline(job_id)
     if pipeline is None:
         raise HTTPException(404, "pipeline not running")
 

--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -6,7 +6,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from threading import Lock
-from typing import Any, Coroutine, Deque, cast
+from typing import Any, Coroutine, Deque, TypedDict, cast
 from uuid import uuid4
 import asyncio
 import inspect
@@ -28,6 +28,17 @@ from .ume.models import TaskRun, TaskSpec
 from . import research
 from .async_utils import run_coroutine
 import time
+
+
+class EventKwargs(TypedDict, total=False):
+    user_id: str
+    group_id: str
+    run_id: str
+
+
+class SpecKwargs(TypedDict, total=False):
+    user_id: str
+    group_id: str
 
 
 class PrecheckError(RuntimeError):
@@ -65,7 +76,7 @@ class TaskPipeline:
             name=self.task.__class__.__name__,
             description=stage,
         )
-        spec_kwargs: dict[str, str | None] = {}
+        spec_kwargs: SpecKwargs = {}
         if user_id is not None:
             spec_kwargs["user_id"] = user_id
         if group_id is not None:
@@ -99,8 +110,8 @@ class TaskPipeline:
 
     def _event_kwargs(
         self, user_id: str | None, group_id: str | None
-    ) -> dict[str, str | None]:
-        kwargs: dict[str, str | None] = {}
+    ) -> EventKwargs:
+        kwargs: EventKwargs = {}
         if user_id is not None:
             kwargs["user_id"] = user_id
         if group_id is not None:

--- a/task_cascadence/pipeline_registry.py
+++ b/task_cascadence/pipeline_registry.py
@@ -1,4 +1,4 @@
-"""Registry of running :class:`~task_cascadence.orchestrator.TaskPipeline` instances."""
+"""Registry of active :class:`~task_cascadence.orchestrator.TaskPipeline` instances."""
 
 from __future__ import annotations
 
@@ -7,8 +7,6 @@ from typing import Any, Dict, Optional
 
 from .orchestrator import TaskPipeline
 
-# Running pipelines keyed by task name and run identifier
-_running_pipelines: Dict[str, Dict[str, TaskPipeline]] = {}
 # Running pipelines keyed by run/job identifier
 _running_pipelines: Dict[str, TaskPipeline] = {}
 # Mapping of run/job identifier back to originating task name
@@ -19,12 +17,25 @@ _task_run_index: Dict[str, list[str]] = {}
 _registry_lock = Lock()
 
 
-def add_pipeline(name: str, run_id: str, pipeline: TaskPipeline) -> None:
-    """Register *pipeline* under *name* and *run_id*."""
+def _get_latest_pipeline_for_task_locked(task_name: str) -> Optional[TaskPipeline]:
+    """Return the most recent pipeline for *task_name* while holding the lock."""
 
-    with _registry_lock:
-        pipelines = _running_pipelines.setdefault(name, {})
-        pipelines[run_id] = pipeline
+    run_ids = _task_run_index.get(task_name)
+    if not run_ids:
+        return None
+
+    for index in range(len(run_ids) - 1, -1, -1):
+        run_id = run_ids[index]
+        pipeline = _running_pipelines.get(run_id)
+        if pipeline is not None:
+            return pipeline
+        # Stale identifier encountered; remove it before continuing.
+        del run_ids[index]
+
+    if not run_ids:
+        _task_run_index.pop(task_name, None)
+    return None
+
 
 def add_pipeline(task_name: str, run_id: str, pipeline: TaskPipeline) -> None:
     """Register *pipeline* for *task_name* under the unique *run_id*."""
@@ -32,84 +43,62 @@ def add_pipeline(task_name: str, run_id: str, pipeline: TaskPipeline) -> None:
     with _registry_lock:
         _running_pipelines[run_id] = pipeline
         _pipeline_tasks[run_id] = task_name
-        runs_for_task = _task_run_index.setdefault(task_name, [])
-        runs_for_task.append(run_id)
+        _task_run_index.setdefault(task_name, []).append(run_id)
 
-def remove_pipeline(name: str, run_id: str) -> None:
-    """Remove the pipeline registered under *name*/*run_id* if present."""
 
-    with _registry_lock:
-        pipelines = _running_pipelines.get(name)
-        if not pipelines:
-            return
-        pipelines.pop(run_id, None)
-        if not pipelines:
-            _running_pipelines.pop(name, None)
-def remove_pipeline(run_id: str) -> None:
-    """Remove the pipeline registered under *run_id* if present."""
+def remove_pipeline(identifier: str, run_id: Optional[str] = None) -> None:
+    """Remove the pipeline identified by *run_id* (or legacy *identifier*).*"""
 
     with _registry_lock:
-        task_name = _pipeline_tasks.pop(run_id, None)
-        _running_pipelines.pop(run_id, None)
-        if task_name is not None:
-            runs_for_task = _task_run_index.get(task_name)
-            if runs_for_task is not None:
+        run_id_key = run_id if run_id is not None else identifier
+        _running_pipelines.pop(run_id_key, None)
+
+        mapped_task = _pipeline_tasks.pop(run_id_key, None)
+        if mapped_task is None and run_id is not None:
+            mapped_task = identifier
+
+        if mapped_task:
+            runs_for_task = _task_run_index.get(mapped_task)
+            if runs_for_task:
                 try:
-                    runs_for_task.remove(run_id)
+                    runs_for_task.remove(run_id_key)
                 except ValueError:  # pragma: no cover - defensive cleanup
                     pass
                 if not runs_for_task:
-                    _task_run_index.pop(task_name, None)
+                    _task_run_index.pop(mapped_task, None)
 
 
-def get_pipeline(run_id: str) -> Optional[TaskPipeline]:
-    """Return the pipeline registered under *run_id* if running."""
+def get_pipeline(identifier: str, run_id: Optional[str] = None) -> Optional[TaskPipeline]:
+    """Return the pipeline registered under *identifier* or *run_id* if running."""
 
     with _registry_lock:
-        return _running_pipelines.get(run_id)
+        if run_id is not None:
+            pipeline = _running_pipelines.get(run_id)
+            if pipeline is None:
+                return None
+            mapped_task = _pipeline_tasks.get(run_id)
+            if mapped_task is None or mapped_task == identifier:
+                return pipeline
+            return None
 
-def get_pipeline(name: str, run_id: Optional[str] = None) -> Optional[TaskPipeline]:
-    """Return the pipeline registered as *name* (optionally filtered by *run_id*)."""
+        pipeline = _running_pipelines.get(identifier)
+        if pipeline is not None:
+            return pipeline
+        return _get_latest_pipeline_for_task_locked(identifier)
+
 
 def get_latest_pipeline_for_task(task_name: str) -> Optional[TaskPipeline]:
     """Return the most recently registered pipeline for *task_name* if running."""
 
     with _registry_lock:
-        run_ids = _task_run_index.get(task_name)
-        if not run_ids:
-            return None
-        # The list is maintained oldest -> newest, so walk backwards to find the
-        # first run id that is still registered. Defensive cleanup ensures stale
-        # identifiers are removed if encountered.
-        for index in range(len(run_ids) - 1, -1, -1):
-            run_id = run_ids[index]
-            pipeline = _running_pipelines.get(run_id)
-            if pipeline is not None:
-                return pipeline
-            # Stale identifier encountered; remove it before continuing.
-            del run_ids[index]
-        if not run_ids:
-            _task_run_index.pop(task_name, None)
-        return None
-
-    with _registry_lock:
-        pipelines = _running_pipelines.get(name)
-        if not pipelines:
-            return None
-        if run_id is not None:
-            return pipelines.get(run_id)
-        if len(pipelines) == 1:
-            return next(iter(pipelines.values()))
-        return None
+        return _get_latest_pipeline_for_task_locked(task_name)
 
 
-def list_pipelines() -> Dict[str, Dict[str, TaskPipeline]]:
-    """Return a copy of the currently registered pipelines."""
 def list_pipelines() -> Dict[str, TaskPipeline]:
     """Return a copy of the currently registered pipelines keyed by run id."""
 
     with _registry_lock:
-        return {name: dict(pipes) for name, pipes in _running_pipelines.items()}
+        return dict(_running_pipelines)
 
 
 def attach_pipeline_context(
@@ -128,11 +117,26 @@ def attach_pipeline_context(
     Returns ``True`` when a pipeline was found and context enqueued.
     """
 
-    pipeline = get_pipeline(name, run_id=run_id)
-    pipeline = get_pipeline(run_id_or_task)
+    with _registry_lock:
+        if run_id is not None:
+            pipeline = _running_pipelines.get(run_id)
+        else:
+            pipeline = _running_pipelines.get(run_id_or_task)
+            if pipeline is None:
+                pipeline = _get_latest_pipeline_for_task_locked(run_id_or_task)
+
     if pipeline is None:
-        pipeline = get_latest_pipeline_for_task(run_id_or_task)
-        if pipeline is None:
-            return False
+        return False
+
     pipeline.attach_context(context, user_id=user_id, group_id=group_id)
     return True
+
+
+__all__ = [
+    "add_pipeline",
+    "remove_pipeline",
+    "get_pipeline",
+    "get_latest_pipeline_for_task",
+    "list_pipelines",
+    "attach_pipeline_context",
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 import tempfile
 
 from task_cascadence.api import app
-from task_cascadence.scheduler import CronScheduler
+from task_cascadence.scheduler import CronScheduler, TaskExecutionResult
 from task_cascadence.plugins import CronTask
 import yaml
 
@@ -84,7 +84,9 @@ def test_run_task(monkeypatch, tmp_path):
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
     )
     assert resp.status_code == 200
-    assert resp.json() == {"result": "ok"}
+    data = resp.json()
+    assert data["result"] == "ok"
+    assert data["run_id"]
     assert task.ran == 1
 
 
@@ -106,7 +108,9 @@ def test_run_task_async_endpoint(monkeypatch, tmp_path):
     )
 
     assert resp.status_code == 200
-    assert resp.json() == {"result": "async"}
+    data = resp.json()
+    assert data["result"] == "async"
+    assert data["run_id"]
 
 
 def test_run_task_user_header(monkeypatch, tmp_path):
@@ -114,10 +118,10 @@ def test_run_task_user_header(monkeypatch, tmp_path):
 
     def fake_run(name, use_temporal=False, user_id=None, group_id=None):
         called["uid"] = user_id
-        return "r"
+        return TaskExecutionResult(run_id="demo", result="r")
 
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
-    monkeypatch.setattr(sched, "run_task", fake_run)
+    monkeypatch.setattr(sched, "run_task_with_metadata", fake_run)
     client = TestClient(app)
     client.post(
         "/tasks/dummy/run",
@@ -131,10 +135,10 @@ def test_run_task_group_header(monkeypatch, tmp_path):
 
     def fake_run(name, use_temporal=False, user_id=None, group_id=None):
         called["gid"] = group_id
-        return "r"
+        return TaskExecutionResult(run_id="demo", result="r")
 
     sched, _ = setup_scheduler(monkeypatch, tmp_path)
-    monkeypatch.setattr(sched, "run_task", fake_run)
+    monkeypatch.setattr(sched, "run_task_with_metadata", fake_run)
     client = TestClient(app)
     client.post(
         "/tasks/dummy/run",

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -173,9 +173,12 @@ def test_api_context_signal(monkeypatch, tmp_path):
     thread.start()
 
     assert task.research_started.wait(timeout=1)
+    pipeline = get_pipeline("contextsignal")
+    assert pipeline is not None
+    run_id = pipeline.current_run_id
 
     resp = client.post(
-        "/tasks/contextsignal/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "context", "value": {"note": "hi"}},
     )

--- a/tests/test_context_signal.py
+++ b/tests/test_context_signal.py
@@ -196,9 +196,10 @@ def test_api_context_signal_delivery(monkeypatch: pytest.MonkeyPatch, tmp_path) 
     assert task.research_started.wait(timeout=1)
     pipeline = get_pipeline("api-context")
     assert pipeline is not None
+    run_id = pipeline.current_run_id
 
     resp = client.post(
-        "/tasks/api-context/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "context", "value": {"note": "hello"}},
     )
@@ -229,8 +230,12 @@ def test_api_context_signal_rejects_unsupported_kind(
 
     assert task.research_started.wait(timeout=1)
 
+    pipeline = get_pipeline("api-context")
+    assert pipeline is not None
+    run_id = pipeline.current_run_id
+
     resp = client.post(
-        "/tasks/api-context/signal",
+        f"/tasks/{run_id}/signal",
         headers={"X-User-ID": "alice", "X-Group-ID": "team"},
         json={"kind": "unknown", "value": {}},
     )
@@ -252,7 +257,7 @@ def test_api_context_signal_rejects_unsupported_kind(
 def test_api_context_signal_missing_headers(headers, expected) -> None:
     client = TestClient(app)
     resp = client.post(
-        "/tasks/example/signal",
+        "/tasks/demo-run/signal",
         headers=headers,
         json={"kind": "context", "value": {}},
     )

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -19,7 +19,7 @@ def test_disambiguation_with_context(monkeypatch):
     resp = client.post(
         '/intent',
         json={'message': 'Schedule it for tomorrow', 'context': ['send email to bob@example.com']},
-        headers={'X-User-ID': 'u1'}
+        headers={'X-User-ID': 'u1', 'X-Group-ID': 'g1'}
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -35,7 +35,11 @@ def test_clarification_triggered(monkeypatch):
 
     monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
     client = TestClient(app)
-    resp = client.post('/intent', json={'message': 'do something', 'context': []}, headers={'X-User-ID': 'u1'})
+    resp = client.post(
+        '/intent',
+        json={'message': 'do something', 'context': []},
+        headers={'X-User-ID': 'u1', 'X-Group-ID': 'g1'}
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert data['clarification']
@@ -52,7 +56,11 @@ def test_sanitization_prevents_injection(monkeypatch):
     monkeypatch.setattr('task_cascadence.intent.gather', fake_gather)
     client = TestClient(app)
     malicious = "<script>alert('x')</script>; rm -rf / 4111111111111111 bob@example.com"
-    resp = client.post('/intent', json={'message': malicious, 'context': []}, headers={'X-User-ID': 'u1'})
+    resp = client.post(
+        '/intent',
+        json={'message': malicious, 'context': []},
+        headers={'X-User-ID': 'u1', 'X-Group-ID': 'g1'}
+    )
     assert resp.status_code == 200
     prompt = captured['prompt']
     assert '<script>' not in prompt

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -89,8 +89,17 @@ def test_pipeline_group_id(monkeypatch):
     def fake_run(run, user_id=None, group_id=None):
         emitted.append(("run", group_id))
 
-    def fake_stage(task_name, stage, client=None, user_id=None, group_id=None, use_asyncio=False):
-        emitted.append((stage, group_id))
+    def fake_stage(
+        task_name,
+        stage,
+        client=None,
+        user_id=None,
+        group_id=None,
+        use_asyncio=False,
+        run_id=None,
+        **_kwargs,
+    ):
+        emitted.append((stage, group_id, run_id))
 
     monkeypatch.setattr("task_cascadence.orchestrator.emit_task_spec", fake_spec)
     monkeypatch.setattr("task_cascadence.orchestrator.emit_task_run", fake_run)
@@ -105,7 +114,7 @@ def test_pipeline_group_id(monkeypatch):
     pipeline = TaskPipeline(Simple())
     pipeline.run(user_id="alice", group_id="team1")
 
-    gids = [g for _, g in emitted]
+    gids = [entry[1] for entry in emitted]
     assert gids and all(g == "team1" for g in gids)
 
 

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -73,7 +73,10 @@ def test_cli_stage_events(monkeypatch, tmp_path):
     ume._stage_store = None
 
     runner = CliRunner()
-    result = runner.invoke(app, ["run", "example", "--user-id", "bob"])
+    result = runner.invoke(
+        app,
+        ["run", "example", "--user-id", "bob", "--group-id", "ops"],
+    )
     assert result.exit_code == 0
 
     data = yaml.safe_load(path.read_text())

--- a/tests/test_yaml_schedule.py
+++ b/tests/test_yaml_schedule.py
@@ -272,14 +272,10 @@ def test_yaml_calendar_event_multiple_recurrences(tmp_path, monkeypatch):
 
     pr_mod = types.ModuleType("task_cascadence.pipeline_registry")
 
-    def add_pipeline(name, run_id, pipeline):  # pragma: no cover - stub
-        pass
-
-    def remove_pipeline(name, run_id):  # pragma: no cover - stub
     def add_pipeline(task_name, run_id, pipeline):  # pragma: no cover - stub
         pass
 
-    def remove_pipeline(run_id):  # pragma: no cover - stub
+    def remove_pipeline(identifier, run_id=None):  # pragma: no cover - stub
         pass
 
     pr_mod.add_pipeline = add_pipeline


### PR DESCRIPTION
## Summary
- return run IDs from the synchronous and async task APIs, accept optional job IDs on pause/resume, and route signals through `/tasks/{job_id}/signal`
- show run IDs in CLI output, add `--job-id` targeting, and refactor the pipeline registry/event helpers to track executions by run ID
- refresh documentation and automated tests to cover the new run ID behavior and job-scoped signaling

## Testing
- pytest
- python -m mypy .


------
https://chatgpt.com/codex/tasks/task_e_68e3d9a41fd48326b8e5adefa55a75c3