### PR TITLE
Align stage update names with audit stages

### DIFF
--- a/task_cascadence/orchestrator.py
+++ b/task_cascadence/orchestrator.py
@@ -334,7 +334,7 @@ class TaskPipeline:
             elif ai_plan is not None and hasattr(ai_plan, "plan"):
                 plan_result = ai_plan.plan(self.task)
         except Exception as exc:
-            self._emit_stage("planning", user_id, group_id)
+            self._emit_stage("plan", user_id, group_id)
             partial = (
                 plan_result
                 if plan_result is not None
@@ -349,7 +349,7 @@ class TaskPipeline:
                 **self._event_kwargs(user_id, group_id),
             )
             raise
-        self._emit_stage("planning", user_id, group_id)
+        self._emit_stage("plan", user_id, group_id)
         emit_audit_log(
             task_name,
             "plan",
@@ -594,7 +594,7 @@ class TaskPipeline:
 
                         verify_result = _await_verify()
         except Exception as exc:
-            self._emit_stage("verification", user_id, group_id)
+            self._emit_stage("verify", user_id, group_id)
             partial = getattr(exc, "partial", None)
             if partial is None and verify_result is not None and verify_result is not exec_result:
                 partial = verify_result
@@ -607,7 +607,7 @@ class TaskPipeline:
                 **self._event_kwargs(user_id, group_id),
             )
             raise
-        self._emit_stage("verification", user_id, group_id)
+        self._emit_stage("verify", user_id, group_id)
         emit_audit_log(
             task_name,
             "verify",

--- a/tests/test_optional_research.py
+++ b/tests/test_optional_research.py
@@ -35,4 +35,4 @@ def test_pipeline_runs_without_tino_storm(monkeypatch):
     result = pipeline.run(user_id="u1")
 
     assert result == "ok"
-    assert emitted == ["intake", "research", "planning", "run", "verification"]
+    assert emitted == ["intake", "research", "plan", "run", "verify"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -77,7 +77,7 @@ def test_pipeline_without_optional(monkeypatch):
     result = pipeline.run(user_id="bob")
 
     assert result == "done"
-    assert emitted == ["intake", "research", "planning", "run", "verification"]
+    assert emitted == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_pipeline_group_id(monkeypatch):
@@ -401,10 +401,10 @@ def test_async_verify(monkeypatch, tmp_path):
     result = pipeline.run(user_id="alice")
 
     assert result == "verified:done"
-    assert stages == ["intake", "research", "planning", "run", "verification"]
+    assert stages == ["intake", "research", "plan", "run", "verify"]
 
     events = StageStore(path=tmp_path / "stages.yml").get_events("AsyncTask")
-    assert [e["stage"] for e in events] == ["intake", "research", "planning", "run", "verification"]
+    assert [e["stage"] for e in events] == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_pipeline_run_async(monkeypatch):
@@ -455,10 +455,10 @@ def test_run_async_parallel_plan(monkeypatch, tmp_path):
     result = asyncio.run(pipeline.run_async(user_id="alice"))
 
     assert sorted(result) == ["a", "b"]
-    assert stages == ["intake", "research", "planning", "run", "verification"]
+    assert stages == ["intake", "research", "plan", "run", "verify"]
 
     events = StageStore(path=tmp_path / "stages.yml").get_events("Parent")
-    assert [e["stage"] for e in events] == ["intake", "research", "planning", "run", "verification"]
+    assert [e["stage"] for e in events] == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_run_list_plan_emits_run_stage(monkeypatch, tmp_path):
@@ -495,10 +495,10 @@ def test_run_list_plan_emits_run_stage(monkeypatch, tmp_path):
     result = pipeline.run(user_id="alice")
 
     assert result == ["a", "b"]
-    assert stages == ["intake", "research", "planning", "run", "verification"]
+    assert stages == ["intake", "research", "plan", "run", "verify"]
 
     events = StageStore(path=tmp_path / "stages.yml").get_events("Parent")
-    assert [e["stage"] for e in events] == ["intake", "research", "planning", "run", "verification"]
+    assert [e["stage"] for e in events] == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_run_error_logs(monkeypatch):

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -43,7 +43,7 @@ def test_pipeline_research(monkeypatch):
 
     assert result == "ok"
     assert steps == ["research:foo:u1", "plan", "run", "verify:result"]
-    assert emitted == ["intake", "research", "planning", "run", "verification"]
+    assert emitted == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_async_pipeline_research(monkeypatch):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -435,7 +435,7 @@ def test_scheduled_job_runs_pipeline(monkeypatch, tmp_path):
 
     data = yaml.safe_load(path.read_text())
     stages = [e["stage"] for e in data["DemoTask"]]
-    assert stages == ["intake", "research", "planning", "run", "verification"]
+    assert stages == ["intake", "research", "plan", "run", "verify"]
 
 
 def test_scheduler_audit_hash_matches_pipeline(monkeypatch, tmp_path):

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -52,7 +52,7 @@ def test_pipeline_stage_events(monkeypatch, tmp_path):
     data = yaml.safe_load(path.read_text())
     events = data["DemoTask"]
     stages = [e["stage"] for e in events]
-    assert stages == ["intake", "research", "planning", "run", "verification"]
+    assert stages == ["intake", "research", "plan", "run", "verify"]
     for e in events:
         assert e["user_hash"] == _hash_user_id("alice")
 
@@ -179,7 +179,7 @@ def test_emit_stage_update_event_default_client(monkeypatch, tmp_path):
     client = Client()
     monkeypatch.setattr(ume, "_default_client", client)
 
-    ume.emit_stage_update_event("demo", "planning", user_id="bob", group_id="devs")
+    ume.emit_stage_update_event("demo", "plan", user_id="bob", group_id="devs")
 
     assert isinstance(client.events[0], StageUpdate)
     assert client.events[0].user_hash == _hash_user_id("bob")


### PR DESCRIPTION
### Motivation

- Ensure stage update events use the canonical identifiers (`plan`, `verify`, etc.) that match audit logs and README documentation.
- Avoid having different stage names emitted from the pipeline which could confuse consumers of stage events and stored stage histories.

### Description

- Replace `planning` → `plan` and `verification` → `verify` for `TaskPipeline` stage emissions by updating `_emit_stage` callers in `task_cascadence/orchestrator.py` (both error and success paths).
- Refresh expectations in pipeline-related tests to assert the new canonical stage identifiers, updating test files including `tests/test_orchestrator.py`, `tests/test_ume_events.py`, `tests/test_research.py`, `tests/test_scheduler.py`, and `tests/test_optional_research.py`.

### Testing

- Ran `python -m ruff check .` and all linter checks passed.
- Attempted `python -m pytest` but the run failed due to `pytest` being invoked with `--cov` options from `pytest.ini` while `pytest-cov` is not available in the environment, so full test suite was not executed.
- Updated tests were adjusted to reflect the canonical stage names and are ready to run in an environment with `pytest-cov` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694818e32e44832698cb81b26dc475b4)