### PR TITLE
Enforce strict pipeline run lookups for signals

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from ..scheduler import get_default_scheduler, CronScheduler
 from ..stage_store import StageStore
 from ..cli import _pointer_add, _pointer_list, _pointer_receive
-from ..pipeline_registry import get_pipeline
+from ..pipeline_registry import get_pipeline, get_latest_pipeline_for_task
 from ..plugins import load_plugin
 from ..task_store import TaskStore
 from ..suggestions.engine import get_default_engine
@@ -267,11 +267,11 @@ def pause_task(
     try:
         pipeline = None
         if job_id is not None:
-            pipeline = get_pipeline(name, run_id=job_id)
+            pipeline = get_pipeline(job_id)
             if pipeline is None:
                 raise HTTPException(404, "pipeline not running")
         else:
-            pipeline = get_pipeline(name)
+            pipeline = get_latest_pipeline_for_task(name)
         if pipeline:
             if user_id is None:
                 raise HTTPException(400, "user_id is required")
@@ -297,11 +297,11 @@ def resume_task(
     try:
         pipeline = None
         if job_id is not None:
-            pipeline = get_pipeline(name, run_id=job_id)
+            pipeline = get_pipeline(job_id)
             if pipeline is None:
                 raise HTTPException(404, "pipeline not running")
         else:
-            pipeline = get_pipeline(name)
+            pipeline = get_latest_pipeline_for_task(name)
         if pipeline:
             if user_id is None:
                 raise HTTPException(400, "user_id is required")

--- a/task_cascadence/cli/__init__.py
+++ b/task_cascadence/cli/__init__.py
@@ -17,7 +17,7 @@ from ..scheduler import (
     CronScheduler,
     BaseScheduler,
 )
-from ..pipeline_registry import get_pipeline
+from ..pipeline_registry import get_pipeline, get_latest_pipeline_for_task
 from .. import plugins  # noqa: F401
 from ..metrics import start_metrics_server  # noqa: F401
 from ..pointer_store import PointerStore
@@ -240,11 +240,11 @@ def pause_task(
     try:
         pipeline = None
         if job_id is not None:
-            pipeline = get_pipeline(name, run_id=job_id)
+            pipeline = get_pipeline(job_id)
             if pipeline is None:
                 raise ValueError("pipeline not running")
         else:
-            pipeline = get_pipeline(name)
+            pipeline = get_latest_pipeline_for_task(name)
         if pipeline:
             if user_id is None:
                 raise typer.BadParameter("--user-id is required when pausing a running task")
@@ -269,11 +269,11 @@ def resume_task(
     try:
         pipeline = None
         if job_id is not None:
-            pipeline = get_pipeline(name, run_id=job_id)
+            pipeline = get_pipeline(job_id)
             if pipeline is None:
                 raise ValueError("pipeline not running")
         else:
-            pipeline = get_pipeline(name)
+            pipeline = get_latest_pipeline_for_task(name)
         if pipeline:
             if user_id is None:
                 raise typer.BadParameter("--user-id is required when resuming a running task")
@@ -621,4 +621,3 @@ __all__ = [
     "capability_planner_cmd",
     "ai_idea",
 ]
-

--- a/task_cascadence/pipeline_registry.py
+++ b/task_cascadence/pipeline_registry.py
@@ -64,26 +64,11 @@ def _clean_latest_for_task(task_name: str) -> Optional[TaskPipeline]:
     return None
 
 
-def get_pipeline(identifier: str, *, run_id: str | None = None) -> Optional[TaskPipeline]:
-    """Return the pipeline registered as *identifier*.
-
-    ``identifier`` is treated as a run identifier first. For backward
-    compatibility, when no pipeline exists for the identifier it falls back to
-    the most recent pipeline registered for the task of the same name. A
-    specific *run_id* can be provided to bypass the lookup heuristic.
-    """
+def get_pipeline(run_id: str) -> Optional[TaskPipeline]:
+    """Return the pipeline registered under the exact *run_id*."""
 
     with _registry_lock:
-        if run_id is not None:
-            pipeline = _running_pipelines.get(run_id)
-            if pipeline is not None:
-                return pipeline
-
-        pipeline = _running_pipelines.get(identifier)
-        if pipeline is not None:
-            return pipeline
-
-        return _clean_latest_for_task(identifier)
+        return _running_pipelines.get(run_id)
 
 
 def get_latest_pipeline_for_task(task_name: str) -> Optional[TaskPipeline]:
@@ -101,21 +86,18 @@ def list_pipelines() -> Dict[str, TaskPipeline]:
 
 
 def attach_pipeline_context(
-    run_id_or_task: str,
+    run_id: str,
     context: Any,
     *,
     user_id: str | None = None,
     group_id: str | None = None,
 ) -> bool:
-    """Attach *context* to the running pipeline identified by *run_id_or_task*.
+    """Attach *context* to the running pipeline identified by *run_id*.
 
-    The identifier is treated as a run/job identifier first. For backward
-    compatibility the lookup falls back to the latest pipeline registered for
-    the task of the same name when no pipeline exists for the identifier.
     Returns ``True`` when a pipeline was found and context enqueued.
     """
 
-    pipeline = get_pipeline(run_id_or_task)
+    pipeline = get_pipeline(run_id)
     if pipeline is None:
         return False
     pipeline.attach_context(context, user_id=user_id, group_id=group_id)

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -7,7 +7,11 @@ from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.stage_store import StageStore
 from task_cascadence.ume import _hash_user_id, emit_audit_log, emit_stage_update_event
-from task_cascadence.pipeline_registry import add_pipeline, get_pipeline, remove_pipeline
+from task_cascadence.pipeline_registry import (
+    add_pipeline,
+    get_latest_pipeline_for_task,
+    remove_pipeline,
+)
 from task_cascadence.orchestrator import TaskPipeline
 import threading
 import time
@@ -83,7 +87,7 @@ def test_api_pause_running_pipeline(monkeypatch, tmp_path):
         headers={"X-User-ID": "bob", "X-Group-ID": "builders"},
     )
     assert resp.status_code == 200
-    pipeline = get_pipeline("slow")
+    pipeline = get_latest_pipeline_for_task("slow")
     assert pipeline is not None and pipeline._paused is True
     assert thread.is_alive()
     resp = client.post(
@@ -303,7 +307,7 @@ def _start_context_signal_pipeline(monkeypatch, tmp_path):
     thread.start()
 
     assert task.research_started.wait(timeout=1)
-    pipeline = get_pipeline("contextsignal")
+    pipeline = get_latest_pipeline_for_task("contextsignal")
     assert pipeline is not None
     run_id = pipeline.current_run_id
     assert run_id is not None
@@ -495,9 +499,15 @@ def test_parallel_context_signals_route_to_matching_pipeline(monkeypatch):
             headers={"X-User-ID": "bob", "X-Group-ID": "ops"},
             json={"kind": "context", "value": {"note": "two"}},
         )
+        resp_mismatched = client.post(
+            "/tasks/parallel-context/signal",
+            headers={"X-User-ID": "carol", "X-Group-ID": "ops"},
+            json={"kind": "context", "value": {"note": "wrong"}},
+        )
 
         assert resp_one.status_code == 202
         assert resp_two.status_code == 202
+        assert resp_mismatched.status_code == 404
 
         task_one.allow_plan.set()
         task_two.allow_plan.set()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from task_cascadence.scheduler import get_default_scheduler, BaseScheduler, Cron
 from task_cascadence import initialize
 from task_cascadence.temporal import TemporalBackend
 from task_cascadence import ume
-from task_cascadence.pipeline_registry import get_pipeline
+from task_cascadence.pipeline_registry import get_latest_pipeline_for_task
 
 
 def test_cli_main_returns_none():
@@ -610,7 +610,7 @@ def test_cli_run_outputs_run_id_and_supports_signal(monkeypatch, tmp_path):
 
     assert task.research_started.wait(timeout=1)
 
-    pipeline = get_pipeline("cli-context")
+    pipeline = get_latest_pipeline_for_task("cli-context")
     assert pipeline is not None
     run_id = pipeline.current_run_id
     assert run_id is not None
@@ -800,6 +800,5 @@ def test_cli_disable_prevents_run(monkeypatch):
     )
     assert result.exit_code != 0
     assert "disabled" in (result.stderr or result.output)
-
 
 

--- a/tests/test_cli_pause.py
+++ b/tests/test_cli_pause.py
@@ -4,7 +4,7 @@ from task_cascadence.cli import app
 from task_cascadence.scheduler import CronScheduler
 from task_cascadence.plugins import ExampleTask, CronTask
 from task_cascadence.stage_store import StageStore
-from task_cascadence.pipeline_registry import get_pipeline
+from task_cascadence.pipeline_registry import get_latest_pipeline_for_task
 from task_cascadence.orchestrator import TaskPipeline
 import asyncio
 import inspect
@@ -109,7 +109,7 @@ def test_pause_running_pipeline(monkeypatch, tmp_path):
         ["pause", "slow", "--user-id", "bob", "--group-id", "ops"],
     )
     assert result.exit_code == 0
-    pipeline = get_pipeline("slow")
+    pipeline = get_latest_pipeline_for_task("slow")
     assert pipeline is not None and pipeline._paused is True
     assert thread.is_alive()
     result = runner.invoke(
@@ -179,4 +179,3 @@ def test_pipeline_pause_non_blocking(monkeypatch):
         assert ran["flag"] is True
 
     asyncio.run(main())
-

--- a/tests/test_context_signal.py
+++ b/tests/test_context_signal.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from task_cascadence.api import app
 from task_cascadence.orchestrator import TaskPipeline
 from task_cascadence.plugins import BaseTask
-from task_cascadence.pipeline_registry import get_pipeline
+from task_cascadence.pipeline_registry import get_latest_pipeline_for_task
 from task_cascadence.scheduler import CronScheduler
 
 
@@ -201,7 +201,7 @@ def test_api_context_signal_delivery(monkeypatch: pytest.MonkeyPatch, tmp_path) 
     thread.start()
 
     assert task.research_started.wait(timeout=1)
-    pipeline = get_pipeline("api-context")
+    pipeline = get_latest_pipeline_for_task("api-context")
     assert pipeline is not None
     run_id = pipeline.current_run_id
     assert run_id is not None
@@ -221,7 +221,7 @@ def test_api_context_signal_delivery(monkeypatch: pytest.MonkeyPatch, tmp_path) 
     assert task.plan_contexts == [[{"note": "hello"}]]
     assert task.run_contexts == [[{"note": "hello"}]]
     assert task.verify_contexts == [[{"note": "hello"}]]
-    assert get_pipeline("api-context") is None
+    assert get_latest_pipeline_for_task("api-context") is None
 
 
 def test_api_context_signal_immediate_delivery(
@@ -237,7 +237,7 @@ def test_api_context_signal_immediate_delivery(
     thread.start()
 
     assert task.research_started.wait(timeout=1)
-    pipeline = get_pipeline("api-context")
+    pipeline = get_latest_pipeline_for_task("api-context")
     assert pipeline is not None
     run_id = pipeline.current_run_id
     assert run_id is not None
@@ -266,7 +266,7 @@ def test_api_context_signal_immediate_delivery(
     assert task.plan_contexts == [[{"note": "instant"}]]
     assert task.run_contexts == [[{"note": "instant"}]]
     assert task.verify_contexts == [[{"note": "instant"}]]
-    assert get_pipeline("api-context") is None
+    assert get_latest_pipeline_for_task("api-context") is None
 
 
 def test_pipeline_acknowledges_idle_context(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -293,7 +293,7 @@ def test_api_context_signal_rejects_unsupported_kind(
 
     assert task.research_started.wait(timeout=1)
 
-    pipeline = get_pipeline("api-context")
+    pipeline = get_latest_pipeline_for_task("api-context")
     assert pipeline is not None
     run_id = pipeline.current_run_id
     assert run_id is not None

--- a/tests/test_pipeline_registry.py
+++ b/tests/test_pipeline_registry.py
@@ -111,7 +111,7 @@ def test_pipeline_lookup_helpers():
         # Removing the latest should cause the previous run to be returned next
         remove_pipeline("run-2", task_name="demo")
         assert get_latest_pipeline_for_task("demo") is first_pipeline
-        # Fallback by task name should succeed while the first pipeline remains
-        assert attach_pipeline_context("demo", {"payload": 2}) is True
+        assert get_pipeline("demo") is None
+        assert attach_pipeline_context("demo", {"payload": 2}) is False
     finally:
         remove_pipeline("run-1", task_name="demo")


### PR DESCRIPTION
### Motivation
- Prevent signals and context from being routed to unrelated runs by removing the task-name fallback and resolving pipelines strictly by run/job ID so the exact run must be targeted.
- Ensure pause/resume behavior still supports acting on the most-recent run when no run ID is provided by introducing a dedicated latest-run helper.

### Description
- Make `get_pipeline` strict: change signature to `get_pipeline(run_id: str)` and return the exact pipeline registered under that run id only.
- Add and use `get_latest_pipeline_for_task` for task-name semantics where appropriate, and update `attach_pipeline_context` to require a `run_id`.
- Update API and CLI endpoints (`signal_task`, `pause_task`, `resume_task` and corresponding CLI commands) to call `get_pipeline(job_id)` when a `job_id`/`run_id` is provided and to call `get_latest_pipeline_for_task(name)` only when operating by task name.
- Adjust and extend tests to cover strict run-ID routing and concurrent runs, including rejecting task-name based signals (`tests/test_api_pipeline.py`, `tests/test_context_signal.py`, `tests/test_pipeline_registry.py`, `tests/test_cli.py`, `tests/test_cli_pause.py`).

### Testing
- Ran `ruff check .` and it passed successfully.
- Attempted to run `pytest`, but the run failed immediately due to the test runner configuration requiring `pytest-cov` via `--cov` in `pytest.ini` (plugin not available), so the full test suite was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697837622ea4832680e12aafef9f0b18)