### PR TITLE
Add TemporalBackend signal/query support with sync wrappers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,36 @@ The :mod:`task_cascadence.temporal` module wraps the ``temporalio`` client.
 Schedulers can use this backend to execute workflows remotely and replay
 workflow histories for debugging purposes.
 
+```python
+from task_cascadence.temporal import TemporalBackend
+
+backend = TemporalBackend("localhost:7233")
+
+# Execute a workflow and wait for completion.
+result = backend.run_workflow_sync(
+    "CalendarWorkflow",
+    {"event": "team-sync"},
+    id="calendar-workflow-1",
+    task_queue="calendar-tasks",
+)
+
+# Signal a running workflow (for example, to attach user/group context).
+backend.signal_workflow_sync(
+    "calendar-workflow-1",
+    "attach_context",
+    {"user_id": "alice", "group_id": "engineering"},
+    run_id="workflow-run-id",
+)
+
+# Query workflow state or context snapshots.
+context = backend.query_workflow_sync(
+    "calendar-workflow-1",
+    "current_context",
+    run_id="workflow-run-id",
+    include_history=True,
+)
+```
+
 ## Task Orchestrator
 
 Tasks can be executed through the :class:`~task_cascadence.orchestrator.TaskPipeline`.
@@ -867,4 +897,3 @@ pytest
 ```
 
 The test suite requires ``protobuf>=6``.
-

--- a/task_cascadence/temporal.py
+++ b/task_cascadence/temporal.py
@@ -33,6 +33,70 @@ class TemporalBackend:
         """Synchronously execute ``workflow`` and return its result."""
         return run_coroutine(self.run_workflow(workflow, *args, **kwargs))
 
+    async def signal_workflow(
+        self,
+        workflow_id: str,
+        signal: str,
+        *signal_args: Any,
+        run_id: str | None = None,
+        **signal_kwargs: Any,
+    ) -> Any:
+        """Signal an existing workflow execution."""
+        client = await self.connect()
+        workflow_handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+        return await workflow_handle.signal(signal, *signal_args, **signal_kwargs)
+
+    def signal_workflow_sync(
+        self,
+        workflow_id: str,
+        signal: str,
+        *signal_args: Any,
+        run_id: str | None = None,
+        **signal_kwargs: Any,
+    ) -> Any:
+        """Synchronously signal an existing workflow execution."""
+        return run_coroutine(
+            self.signal_workflow(
+                workflow_id,
+                signal,
+                *signal_args,
+                run_id=run_id,
+                **signal_kwargs,
+            )
+        )
+
+    async def query_workflow(
+        self,
+        workflow_id: str,
+        query: str,
+        *query_args: Any,
+        run_id: str | None = None,
+        **query_kwargs: Any,
+    ) -> Any:
+        """Query an existing workflow execution."""
+        client = await self.connect()
+        workflow_handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+        return await workflow_handle.query(query, *query_args, **query_kwargs)
+
+    def query_workflow_sync(
+        self,
+        workflow_id: str,
+        query: str,
+        *query_args: Any,
+        run_id: str | None = None,
+        **query_kwargs: Any,
+    ) -> Any:
+        """Synchronously query an existing workflow execution."""
+        return run_coroutine(
+            self.query_workflow(
+                workflow_id,
+                query,
+                *query_args,
+                run_id=run_id,
+                **query_kwargs,
+            )
+        )
+
     def replay(self, history_path: str) -> None:
         """Replay a workflow history from ``history_path`` for debugging."""
         replayer = Replayer()  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,47 @@ class TemporalBackend:  # minimal stub for tests
     def __init__(self) -> None:
         self.server = os.getenv("TEMPORAL_SERVER", "localhost:7233")
 
-    def run_workflow_sync(self, workflow, *args, **kwargs):  # pragma: no cover - patched in tests
-        async def _run():
-            client = await Client.connect(self.server)
-            return await client.execute_workflow(workflow, *args, **kwargs)
+    async def connect(self):
+        return await Client.connect(self.server)
 
-        return asyncio.run(_run())
+    async def run_workflow(self, workflow, *args, **kwargs):
+        client = await self.connect()
+        return await client.execute_workflow(workflow, *args, **kwargs)
+
+    def run_workflow_sync(self, workflow, *args, **kwargs):  # pragma: no cover - patched in tests
+        return asyncio.run(self.run_workflow(workflow, *args, **kwargs))
+
+    async def signal_workflow(self, workflow_id, signal, *signal_args, run_id=None, **signal_kwargs):
+        client = await self.connect()
+        handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+        return await handle.signal(signal, *signal_args, **signal_kwargs)
+
+    def signal_workflow_sync(self, workflow_id, signal, *signal_args, run_id=None, **signal_kwargs):
+        return asyncio.run(
+            self.signal_workflow(
+                workflow_id,
+                signal,
+                *signal_args,
+                run_id=run_id,
+                **signal_kwargs,
+            )
+        )
+
+    async def query_workflow(self, workflow_id, query, *query_args, run_id=None, **query_kwargs):
+        client = await self.connect()
+        handle = client.get_workflow_handle(workflow_id, run_id=run_id)
+        return await handle.query(query, *query_args, **query_kwargs)
+
+    def query_workflow_sync(self, workflow_id, query, *query_args, run_id=None, **query_kwargs):
+        return asyncio.run(
+            self.query_workflow(
+                workflow_id,
+                query,
+                *query_args,
+                run_id=run_id,
+                **query_kwargs,
+            )
+        )
 
     def replay(self, path):  # pragma: no cover - patched in tests
         replayer_cls = sys.modules["task_cascadence.temporal"].Replayer

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -5,6 +5,7 @@ import task_cascadence.temporal as temporal
 import inspect
 from unittest.mock import AsyncMock, Mock
 import asyncio
+import pytest
 
 
 class DummyTask(CronTask):
@@ -92,3 +93,121 @@ def test_backend_server_from_env(monkeypatch):
     monkeypatch.setenv("TEMPORAL_SERVER", "remote:4444")
     backend = TemporalBackend()
     assert backend.server == "remote:4444"
+
+
+def test_signal_workflow_uses_handle(monkeypatch):
+    backend = TemporalBackend()
+    handle = Mock()
+    handle.signal = AsyncMock(return_value="ack")
+
+    client = Mock()
+    client.get_workflow_handle = Mock(return_value=handle)
+    connect_mock = AsyncMock(return_value=client)
+    monkeypatch.setattr(backend, "connect", connect_mock)
+
+    result = asyncio.run(
+        backend.signal_workflow(
+            "workflow-123",
+            "attach_context",
+            {"user_id": "alice"},
+            run_id="run-456",
+            metadata={"source": "api"},
+        )
+    )
+
+    assert result == "ack"
+    client.get_workflow_handle.assert_called_once_with("workflow-123", run_id="run-456")
+    handle.signal.assert_awaited_once_with(
+        "attach_context",
+        {"user_id": "alice"},
+        metadata={"source": "api"},
+    )
+
+
+def test_query_workflow_uses_handle(monkeypatch):
+    backend = TemporalBackend()
+    handle = Mock()
+    handle.query = AsyncMock(return_value={"status": "ready"})
+
+    client = Mock()
+    client.get_workflow_handle = Mock(return_value=handle)
+    connect_mock = AsyncMock(return_value=client)
+    monkeypatch.setattr(backend, "connect", connect_mock)
+
+    result = asyncio.run(
+        backend.query_workflow(
+            "workflow-abc",
+            "fetch_context",
+            "scope-a",
+            run_id="run-def",
+            include_history=True,
+        )
+    )
+
+    assert result == {"status": "ready"}
+    client.get_workflow_handle.assert_called_once_with("workflow-abc", run_id="run-def")
+    handle.query.assert_awaited_once_with("fetch_context", "scope-a", include_history=True)
+
+
+def test_signal_workflow_sync_uses_run_coroutine(monkeypatch):
+    backend = TemporalBackend()
+    monkeypatch.setattr(backend, "signal_workflow", AsyncMock(return_value="synced"))
+
+    result = backend.signal_workflow_sync(
+        "workflow-1",
+        "attach_context",
+        {"group_id": "eng"},
+        run_id="run-1",
+    )
+
+    assert result == "synced"
+    backend.signal_workflow.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "workflow-1",
+        "attach_context",
+        {"group_id": "eng"},
+        run_id="run-1",
+    )
+
+
+def test_query_workflow_sync_uses_run_coroutine(monkeypatch):
+    backend = TemporalBackend()
+    monkeypatch.setattr(backend, "query_workflow", AsyncMock(return_value={"state": "ok"}))
+
+    result = backend.query_workflow_sync(
+        "workflow-2",
+        "current_context",
+        run_id="run-2",
+        with_details=True,
+    )
+
+    assert result == {"state": "ok"}
+    backend.query_workflow.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "workflow-2",
+        "current_context",
+        run_id="run-2",
+        with_details=True,
+    )
+
+
+def test_signal_workflow_propagates_error(monkeypatch):
+    backend = TemporalBackend()
+    handle = Mock()
+    handle.signal = AsyncMock(side_effect=RuntimeError("signal failed"))
+    client = Mock()
+    client.get_workflow_handle = Mock(return_value=handle)
+    monkeypatch.setattr(backend, "connect", AsyncMock(return_value=client))
+
+    with pytest.raises(RuntimeError, match="signal failed"):
+        asyncio.run(backend.signal_workflow("workflow-err", "attach_context"))
+
+
+def test_query_workflow_propagates_error(monkeypatch):
+    backend = TemporalBackend()
+    handle = Mock()
+    handle.query = AsyncMock(side_effect=RuntimeError("query failed"))
+    client = Mock()
+    client.get_workflow_handle = Mock(return_value=handle)
+    monkeypatch.setattr(backend, "connect", AsyncMock(return_value=client))
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        asyncio.run(backend.query_workflow("workflow-err", "current_context"))


### PR DESCRIPTION
### Motivation
- Extend the Temporal backend to allow attaching context to running workflows and inspecting workflow state by adding explicit signal and query APIs. 
- Provide synchronous convenience wrappers that match the existing `run_workflow_sync` pattern so callers can use these features from synchronous code. 

### Description
- Added async methods `signal_workflow` and `query_workflow` to `task_cascadence.temporal.TemporalBackend` that resolve a workflow handle via `workflow_id`/`run_id` and forward positional and keyword payloads to the handle. 
- Added sync wrappers `signal_workflow_sync` and `query_workflow_sync` which execute the async methods via `run_coroutine`, mirroring `run_workflow_sync`. 
- Updated the lightweight Temporal stub in `tests/conftest.py` to expose `connect`, async/sync `run_workflow`, `signal_workflow`, and `query_workflow` so tests can run against the repository's stubbed environment. 
- Added unit tests in `tests/test_temporal.py` covering async behavior, sync wrapper usage, and error propagation for both `signal_workflow` and `query_workflow`, and updated the README Temporal section with example usages of run, signal, and query including workflow id/run id and payloads. 

### Testing
- Ran linter checks with `ruff` on the modified files and they passed for `task_cascadence/temporal.py`, `tests/test_temporal.py`, and `tests/conftest.py`. 
- Executed the temporal-specific test file with `pytest -q tests/test_temporal.py -o addopts=''` and all tests passed (`11 passed`). 
- Note: an initial `pytest` run failed due to repository `pytest.ini` coverage addopts that are not available in this environment, so the targeted test invocation above was used to validate the new test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e6f12874832697758b9cec8ac52d)