### PR TITLE
Normalize canonical task IDs between API registration and CronScheduler

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -9,7 +9,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from ..scheduler import get_default_scheduler, CronScheduler
+from ..scheduler import get_default_scheduler, CronScheduler, normalize_task_id
 from ..stage_store import StageStore
 from ..cli import _pointer_add, _pointer_list, _pointer_receive
 from ..pipeline_registry import get_pipeline, get_latest_pipeline_for_task
@@ -140,14 +140,11 @@ def register_task(
         task = load_plugin(path)
         TaskStore().add_path(path)
         sched.register_task(task.name, task, user_id=user_id, group_id=group_id)
+        canonical_task_id = normalize_task_id(task, task_registry=sched._tasks)
         if schedule:
-            if isinstance(sched, CronScheduler):
-                sched.register_task(
-                    task, schedule, user_id=user_id, group_id=group_id
-                )
-            elif hasattr(sched, "schedule_task"):
+            if hasattr(sched, "schedule_task"):
                 sched.schedule_task(
-                    task.name,
+                    canonical_task_id,
                     schedule,
                     user_id=user_id,
                     group_id=group_id,

--- a/task_cascadence/scheduler/__init__.py
+++ b/task_cascadence/scheduler/__init__.py
@@ -51,6 +51,30 @@ def _maybe_hash_group_id(group_id: str) -> str:
     return group_id if _HASH_RE.match(group_id) else _hash_user_id(group_id)
 
 
+def normalize_task_id(
+    name_or_task: str | Any,
+    *,
+    task_registry: Dict[str, Dict[str, Any]] | None = None,
+) -> str:
+    """Return the canonical identifier for ``name_or_task``.
+
+    Priority order:
+    1. Explicit string identifier.
+    2. Existing registration key in ``task_registry`` for the task object.
+    3. Task class name as fallback.
+    """
+
+    if isinstance(name_or_task, str):
+        return name_or_task
+
+    if task_registry:
+        for task_id, info in task_registry.items():
+            if info.get("task") is name_or_task:
+                return task_id
+
+    return name_or_task.__class__.__name__
+
+
 @dataclass(frozen=True)
 class TaskExecutionResult:
     """Wrapper containing metadata for a task execution."""
@@ -580,7 +604,7 @@ class CronScheduler(BaseScheduler):
                 expr, timezone=self.scheduler.timezone
             )
             self.scheduler.add_job(
-                self._wrap_task(task, user_id=user_id, group_id=group_id),
+                self._wrap_task(job_id, task, user_id=user_id, group_id=group_id),
                 trigger=trigger,
                 id=job_id,
                 replace_existing=True,
@@ -648,28 +672,35 @@ class CronScheduler(BaseScheduler):
             self.schedule_from_event(
                 task, event, user_id=user_id, group_id=group_id
             )
-            job_id = task.__class__.__name__
+            with self._schedules_lock:
+                job_id = normalize_task_id(task, task_registry=self._tasks)
             with self._schedules_lock:
                 sched_entry = self.schedules.get(job_id)
                 if isinstance(sched_entry, dict):
                     sched_entry["calendar_event"] = {"node": node, "poll": interval}
                     self._save_schedules()
 
+        with self._schedules_lock:
+            task_id = normalize_task_id(task, task_registry=self._tasks)
         self.scheduler.add_job(
             _poll,
             "interval",
             seconds=interval,
-            id=f"poll:{task.__class__.__name__}:{node}",
+            id=f"poll:{task_id}:{node}",
             replace_existing=True,
         )
         _poll()
 
     def _wrap_task(
-        self, task, user_id: str | None = None, group_id: str | None = None
+        self,
+        task_id: str,
+        task: Any,
+        user_id: str | None = None,
+        group_id: str | None = None,
     ):
         def runner():
             with self._schedules_lock:
-                info = self._tasks.get(task.__class__.__name__)
+                info = self._tasks.get(task_id)
                 paused = bool(info and info.get("paused"))
                 resolved_user = user_id
                 resolved_group = group_id
@@ -681,7 +712,7 @@ class CronScheduler(BaseScheduler):
             if paused:
                 return
             self.run_task(
-                task.__class__.__name__,
+                task_id,
                 user_id=resolved_user,
                 group_id=resolved_group,
             )
@@ -750,7 +781,8 @@ class CronScheduler(BaseScheduler):
             return
 
         task, cron_expression = name_or_task, task_or_expr
-        job_id = task.__class__.__name__
+        with self._schedules_lock:
+            job_id = normalize_task_id(task, task_registry=self._tasks)
         try:
             super().register_task(
                 job_id, task, user_id=user_id, group_id=group_id
@@ -781,7 +813,7 @@ class CronScheduler(BaseScheduler):
                 cron_expression, timezone=self.scheduler.timezone
             )
             self.scheduler.add_job(
-                self._wrap_task(task, user_id=user_id, group_id=group_id),
+                self._wrap_task(job_id, task, user_id=user_id, group_id=group_id),
                 trigger=trigger,
                 id=job_id,
                 replace_existing=True,
@@ -809,6 +841,12 @@ class CronScheduler(BaseScheduler):
         group_id: str | None = None,
     ) -> None:
         """Convenience wrapper for :meth:`register_task`."""
+        if isinstance(task, str):
+            with self._schedules_lock:
+                info = self._tasks.get(task)
+            if not info:
+                raise ValueError(f"Unknown task: {task}")
+            task = info["task"]
         self.register_task(
             name_or_task=task,
             task_or_expr=cron_expression,
@@ -954,7 +992,8 @@ class CronScheduler(BaseScheduler):
             def emit_audit_log(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
                 return None
 
-        job_id = task.__class__.__name__
+        with self._schedules_lock:
+            job_id = normalize_task_id(task, task_registry=self._tasks)
         recurrence = event.get("recurrence", {})
         expr = recurrence.get("cron")
         group_hash = _maybe_hash_group_id(group_id) if group_id is not None else None
@@ -1239,6 +1278,3 @@ def create_scheduler(
         from .dag import DagCronScheduler
         return DagCronScheduler(timezone=timezone, tasks=tasks)
     raise ValueError(f"Unknown scheduler backend: {backend}")
-
-
-

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,17 @@ class DynamicTask(CronTask):
         return "dyn"
 
 
+class PluginAliasTask(CronTask):
+    name = "plugin_alias"
+
+    def __init__(self):
+        self.ran = 0
+
+    def run(self):
+        self.ran += 1
+        return "alias"
+
+
 class AsyncTask(CronTask):
     name = "async"
 
@@ -321,7 +332,7 @@ def test_schedule_task(monkeypatch, tmp_path):
         headers=REQUIRED_HEADERS,
     )
     assert resp.status_code == 200
-    job = sched.scheduler.get_job("DummyTask")
+    job = sched.scheduler.get_job("dummy")
     assert job is not None
 
 
@@ -431,16 +442,31 @@ def test_register_task_with_schedule(monkeypatch, tmp_path):
         headers=REQUIRED_HEADERS,
     )
     assert resp.status_code == 200
-    job = sched.scheduler.get_job("DynamicTask")
+    job = sched.scheduler.get_job("dynamic")
     assert job is not None
-    task_info = sched._tasks.get("DynamicTask")
+    task_info = sched._tasks.get("dynamic")
     assert task_info is not None
     assert task_info["user_id"] == "alice"
     assert task_info["group_id"] == "team"
 
-    runner = sched._wrap_task(task_info["task"])
+    runner = sched._wrap_task("dynamic", task_info["task"])
     runner()
     assert task_info["task"].ran == 1
+
+
+def test_register_task_with_schedule_uses_plugin_name_as_job_id(monkeypatch, tmp_path):
+    sched, _ = setup_scheduler(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post(
+        "/tasks",
+        params={"path": "tests.test_api:PluginAliasTask", "schedule": "*/7 * * * *"},
+        headers=REQUIRED_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert sched.scheduler.get_job("plugin_alias") is not None
+    assert sched.scheduler.get_job("PluginAliasTask") is None
+    assert "plugin_alias" in sched.schedules
+    assert "PluginAliasTask" not in sched.schedules
 
 
 def test_register_task_invalid_path(monkeypatch, tmp_path):
@@ -475,4 +501,3 @@ def test_register_task_missing_group_header(monkeypatch, tmp_path):
         headers=USER_ONLY_HEADERS,
     )
     assert resp.status_code == 400
-

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -14,6 +14,17 @@ class DummyTask(CronTask):
         return self.count
 
 
+class PluginNamedTask(CronTask):
+    name = "plugin_task"
+
+    def __init__(self):
+        self.count = 0
+
+    def run(self):
+        self.count += 1
+        return self.count
+
+
 def test_timezone_awareness(tmp_path):
     storage = tmp_path / "sched.yml"
     sched = CronScheduler(timezone="US/Pacific", storage_path=storage)
@@ -199,6 +210,20 @@ def test_schedule_task_user_id(tmp_path):
     assert data["DummyTask"]["user_hash"] == _hash_user_id("bob")
 
 
+def test_register_task_preserves_registered_name_when_scheduling(tmp_path):
+    storage = tmp_path / "sched.yml"
+    sched = CronScheduler(timezone="UTC", storage_path=storage)
+    task = PluginNamedTask()
+    sched.register_task(name_or_task="registered_plugin", task_or_expr=task)
+
+    sched.register_task(name_or_task=task, task_or_expr="*/9 * * * *")
+
+    assert sched.scheduler.get_job("registered_plugin") is not None
+    assert sched.scheduler.get_job("PluginNamedTask") is None
+    assert "registered_plugin" in sched.schedules
+    assert "PluginNamedTask" not in sched.schedules
+
+
 def test_base_scheduler_has_no_schedule_task():
     bs = BaseScheduler()
     assert not hasattr(bs, "schedule_task")
@@ -277,7 +302,7 @@ def test_wrap_task_user_id(monkeypatch):
     sched = CronScheduler(timezone="UTC", storage_path="dummy.yml")
     task = DummyTask()
     sched.register_task("DummyTask", task)
-    wrapped = sched._wrap_task(task, user_id="alice")
+    wrapped = sched._wrap_task("DummyTask", task, user_id="alice")
     wrapped()
 
     assert emitted is not None
@@ -537,4 +562,3 @@ def test_cronyx_schedule_task_hash(monkeypatch):
     sched.schedule_task("demo", "* * * * *", user_id="bob")
 
     assert captured["json"]["user_id"] == _hash_user_id("bob")
-


### PR DESCRIPTION
### Motivation
- Ensure a single canonical task identifier is used everywhere to avoid silent id switching when plugin `task.name` differs from the task class name. 
- Preserve the identifier that the scheduler registry uses so APScheduler job ids, persisted `schedules`, and runtime lookups remain consistent. 

### Description
- Add a single-source helper `normalize_task_id(...)` in `task_cascadence.scheduler` to determine the canonical id for a task (string id first, then existing registry key, then class-name fallback). 
- Update `CronScheduler.register_task(...)` to resolve and use the canonical `job_id` when scheduling `(task, cron_expression)`, persist `self.schedules` entries under that id, and pass the `job_id` into the job wrapper. 
- Change `_wrap_task(...)` to accept an explicit `task_id` and use it for runtime lookup and `run_task` calls so execution and pause/disable checks use the canonical id. 
- Update calendar polling, `schedule_from_event`, restore/load flows and `schedule_task` helper to resolve and use canonical ids consistently. 
- Update the API registration endpoint to compute the canonical id after registering the plugin with the scheduler and use that id when requesting scheduling from the scheduler. 
- Add regression tests covering plugin tasks where `task.name != task.__class__.__name__` in `tests/test_api.py` and `tests/test_scheduler.py`, and adjust some existing tests to call the revised `_wrap_task` signature.

### Testing
- Ran `python -m pytest -o addopts='' tests/test_scheduler.py tests/test_api.py -q` and all tests passed (`50 passed`).
- Ran the linter with `ruff check task_cascadence/api/__init__.py task_cascadence/scheduler/__init__.py tests/test_api.py tests/test_scheduler.py` and it reported no issues.
- Note: running pytest with the repository `pytest.ini` default `addopts` failed in this environment due to coverage-related CLI options, so tests were executed with `-o addopts=''` to disable those extra args and validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e6f017b0832693bb3f2b7c1e6244)