### PR TITLE
Add canonical UME event contract with event_type + schema_version for stage/audit

### DIFF
--- a/task_cascadence/ume/__init__.py
+++ b/task_cascadence/ume/__init__.py
@@ -40,6 +40,34 @@ _idea_store: IdeaStore | None = None
 _suggestion_store: SuggestionStore | None = None
 
 
+def _canonical_event_type(stage: str, status: str | None = None) -> str:
+    """Map legacy ``stage`` / ``status`` values to canonical event types."""
+
+    stage_norm = stage.strip().lower()
+    status_norm = status.strip().lower() if status is not None else None
+
+    if stage_norm == "context_attached" or status_norm == "received":
+        return "CONTEXT.ATTACHED"
+    if status_norm in {"started", "start"} or stage_norm in {"start", "started"}:
+        return "TASK.STAGE.STARTED"
+    if status_norm in {"success", "finish", "finished", "completed"} or stage_norm in {
+        "finish",
+        "finished",
+        "completed",
+        "resumed",
+    }:
+        return "TASK.STAGE.SUCCESS"
+    if status_norm in {"error", "failure", "failed"} or stage_norm in {
+        "error",
+        "failure",
+        "failed",
+    }:
+        return "TASK.STAGE.ERROR"
+    if status_norm == "skipped" or stage_norm == "skipped":
+        return "TASK.STAGE.SKIPPED"
+    return "TASK.STAGE.UPDATED"
+
+
 def _prepare_for_transport(obj: Any, client: Any) -> Any:
     """Convert *obj* to the appropriate representation for *client*.
 
@@ -48,6 +76,11 @@ def _prepare_for_transport(obj: Any, client: Any) -> Any:
     the version metadata and return a ``dict`` for non-gRPC clients.
     """
 
+    if isinstance(obj, (StageUpdateSchema, AuditEventSchema)):
+        # During transition to canonical event contracts, always send the
+        # versioned public representation so gRPC and NATS receive identical
+        # payload keys (including ``schema_version`` and ``event_type``).
+        return obj.to_dict()
     if isinstance(client, (GrpcClient, AsyncGrpcClient)) and hasattr(obj, "to_proto"):
         return obj.to_proto()
     if isinstance(client, (NatsClient, AsyncNatsClient)) and hasattr(obj, "to_dict"):
@@ -158,6 +191,7 @@ def emit_stage_update_event(
         user_hash=_hash_user_id(user_id) if user_id is not None else None,
         group_id=group_id,
     )
+    update.event_type = _canonical_event_type(stage)
     payload = _prepare_for_transport(update, target)
     if use_asyncio:
         return asyncio.get_running_loop().create_task(
@@ -216,6 +250,7 @@ def emit_audit_log(
         user_hash=_hash_user_id(user_id) if user_id is not None else None,
         group_id=group_id,
     )
+    event.event_type = _canonical_event_type(stage, status)
     payload = _prepare_for_transport(event, target)
     if use_asyncio:
         return asyncio.get_running_loop().create_task(

--- a/task_cascadence/ume/schema_public.py
+++ b/task_cascadence/ume/schema_public.py
@@ -9,7 +9,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 from . import models
 
-SCHEMA_VERSION = "2024.09.0"
+SCHEMA_VERSION = "2026.04.0"
 
 
 def _ensure_utc(dt: datetime) -> datetime:
@@ -45,6 +45,7 @@ class BaseSchema:
     """Base dataclass for public schemas that embeds version metadata."""
 
     schema_version: str = field(default=SCHEMA_VERSION, init=False)
+    event_type: str = field(default="UNKNOWN", init=False)
 
     def to_dict(self) -> dict[str, Any]:
         return {k: _convert_value(v) for k, v in asdict(self).items()}
@@ -133,6 +134,7 @@ class StageUpdateSchema(BaseSchema):
     user_hash: str | None = None
     user_id: str | None = None
     group_id: str | None = None
+    event_type: str = field(default="TASK.STAGE.UPDATED", init=False)
 
     @classmethod
     def from_proto(cls, message: models.StageUpdate) -> "StageUpdateSchema":
@@ -166,6 +168,7 @@ class AuditEventSchema(BaseSchema):
     user_hash: str | None = None
     user_id: str | None = None
     group_id: str | None = None
+    event_type: str = field(default="TASK.STAGE.UPDATED", init=False)
 
     @classmethod
     def from_proto(cls, message: models.AuditEvent) -> "AuditEventSchema":

--- a/tests/test_ume_events.py
+++ b/tests/test_ume_events.py
@@ -6,7 +6,8 @@ from task_cascadence.cli import app
 from task_cascadence.scheduler import BaseScheduler
 from task_cascadence.plugins import ExampleTask
 from task_cascadence.ume import _hash_user_id, emit_task_note, emit_idea_seed
-from task_cascadence.ume.models import AuditEvent, IdeaSeed, StageUpdate, TaskNote
+from task_cascadence.ume.models import IdeaSeed, TaskNote
+from task_cascadence.ume.schema_public import SCHEMA_VERSION
 
 
 class DemoTask:
@@ -150,13 +151,14 @@ def test_emit_stage_update_event(monkeypatch, tmp_path):
 
     ume.emit_stage_update_event("demo", "start", client, user_id="alice", group_id="devs")
 
-    assert isinstance(client.events[0], StageUpdate)
-    assert client.events[0].user_hash == _hash_user_id("alice")
-    assert client.events[0].user_id == "alice"
-    assert client.events[0].group_id == "devs"
-    serialized = client.events[0].SerializeToString()
-    again = StageUpdate.FromString(serialized)
-    assert again == client.events[0]
+    payload = client.events[0]
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["event_type"] == "TASK.STAGE.STARTED"
+    assert payload["stage"] == "start"  # compatibility for legacy consumers
+    assert payload["user_hash"] == _hash_user_id("alice")
+    assert payload["user_id"] == "alice"
+    assert payload["group_id"] == "devs"
 
     data = yaml.safe_load((tmp_path / "stages.yml").read_text())
     assert data["demo"][0]["user_hash"] == _hash_user_id("alice")
@@ -181,10 +183,14 @@ def test_emit_stage_update_event_default_client(monkeypatch, tmp_path):
 
     ume.emit_stage_update_event("demo", "plan", user_id="bob", group_id="devs")
 
-    assert isinstance(client.events[0], StageUpdate)
-    assert client.events[0].user_hash == _hash_user_id("bob")
-    assert client.events[0].user_id == "bob"
-    assert client.events[0].group_id == "devs"
+    payload = client.events[0]
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["event_type"] == "TASK.STAGE.UPDATED"
+    assert payload["stage"] == "plan"
+    assert payload["user_hash"] == _hash_user_id("bob")
+    assert payload["user_id"] == "bob"
+    assert payload["group_id"] == "devs"
     data = yaml.safe_load((tmp_path / "events.yml").read_text())
     assert data["demo"][0]["user_hash"] == _hash_user_id("bob")
 
@@ -214,12 +220,16 @@ def test_emit_audit_log_emits_event(monkeypatch, tmp_path):
         output="done",
     )
 
-    assert isinstance(client.events[0], AuditEvent)
-    assert client.events[0].user_hash == _hash_user_id("carol")
-    assert client.events[0].user_id == "carol"
-    assert client.events[0].group_id == "devs"
-    assert client.events[0].status == "success"
-    assert client.events[0].output == "done"
+    payload = client.events[0]
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["event_type"] == "TASK.STAGE.SUCCESS"
+    assert payload["stage"] == "run"  # compatibility for legacy consumers
+    assert payload["status"] == "success"  # compatibility for legacy consumers
+    assert payload["user_hash"] == _hash_user_id("carol")
+    assert payload["user_id"] == "carol"
+    assert payload["group_id"] == "devs"
+    assert payload["output"] == "done"
 
     data = yaml.safe_load((tmp_path / "audit.yml").read_text())
     key = "demo:audit"
@@ -254,12 +264,15 @@ def test_emit_audit_log_records_failure(monkeypatch, tmp_path):
         output="oops",
     )
 
-    assert isinstance(client.events[0], AuditEvent)
-    assert client.events[0].status == "failure"
-    assert client.events[0].reason == "bad"
-    assert client.events[0].output == "oops"
-    assert client.events[0].user_hash == _hash_user_id("dave")
-    assert client.events[0].group_id == "ops"
+    payload = client.events[0]
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["event_type"] == "TASK.STAGE.ERROR"
+    assert payload["status"] == "failure"
+    assert payload["reason"] == "bad"
+    assert payload["output"] == "oops"
+    assert payload["user_hash"] == _hash_user_id("dave")
+    assert payload["group_id"] == "ops"
 
     from task_cascadence.stage_store import StageStore
 
@@ -273,3 +286,34 @@ def test_emit_audit_log_records_failure(monkeypatch, tmp_path):
     assert events[0]["status"] == "failure"
     assert events[0]["reason"] == "bad"
     assert events[0]["output"] == "oops"
+
+
+def test_context_attach_audit_event_contract(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASCADENCE_HASH_SECRET", "s")
+    monkeypatch.setenv("CASCADENCE_STAGES_PATH", str(tmp_path / "audit.yml"))
+
+    class Client:
+        def __init__(self) -> None:
+            self.events = []
+
+        def enqueue(self, obj) -> None:
+            self.events.append(obj)
+
+    import task_cascadence.ume as ume
+    ume._stage_store = None
+    client = Client()
+
+    ume.emit_audit_log(
+        "demo",
+        "context_attached",
+        "received",
+        client,
+        user_id="eve",
+        group_id="ops",
+    )
+
+    payload = client.events[0]
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["event_type"] == "CONTEXT.ATTACHED"
+    assert payload["stage"] == "context_attached"
+    assert payload["status"] == "received"


### PR DESCRIPTION
### Motivation
- Provide a stable, versioned event contract for UME stage and audit events by introducing an explicit `event_type` discriminator so downstream consumers can rely on canonical lifecycle semantics.
- Map existing legacy `stage`/`status` combinations to a small set of canonical event types (e.g., `TASK.STAGE.STARTED|SUCCESS|ERROR|SKIPPED`, `CONTEXT.ATTACHED`) to simplify consumer logic.
- Ensure both gRPC and NATS transport paths consistently carry the version metadata (`schema_version`) and the new `event_type` while preserving legacy `stage`/`status` fields for compatibility during migration.

### Description
- Bumped schema version to `2026.04.0` and added `event_type` to `BaseSchema` so all public schemas include the discriminator by default (`task_cascadence/ume/schema_public.py`).
- Added `event_type` fields (with defaults) to `StageUpdateSchema` and `AuditEventSchema` and ensured they are non-init defaults to keep dataclass ordering stable.
- Implemented `_canonical_event_type(stage, status)` to map legacy stage/status values to canonical event types and applied it to instances emitted by `emit_stage_update_event` and `emit_audit_log` (`task_cascadence/ume/__init__.py`).
- Modified `_prepare_for_transport` so `StageUpdateSchema` and `AuditEventSchema` are serialized as the versioned public `dict` for all transports (ensuring `schema_version` and `event_type` exist on gRPC and NATS payloads) and left legacy `stage`/`status` in place for backward compatibility.
- Updated `tests/test_ume_events.py` to assert the new serialized contract (checks for `schema_version` + `event_type`) and added a focused test for the `CONTEXT.ATTACHED` mapping; existing persisted stage/audit storage behavior is unchanged.

### Testing
- Ran linter: `ruff check task_cascadence/ume/schema_public.py task_cascadence/ume/__init__.py tests/test_ume_events.py` and the checks passed.
- Ran focused unit tests with project addopts neutralized due to environment coverage tooling: `pytest -q -o addopts= tests/test_ume_events.py` and all tests passed (`9 passed`).
- Ran a small integration subset: `pytest -q -o addopts= tests/test_transport.py tests/test_ume_events.py tests/test_api_pipeline.py` and all tests passed (`26 passed`).
- Note: running plain `pytest` in this environment triggers project-level coverage args from `pytest.ini` while `pytest-cov` is not available, so test runs above used `-o addopts=` to neutralize CI-only addopts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eb3839248326a27752442475ad15)