### PR TITLE
Remove duplicate scoped dependencies on pipeline endpoints

### DIFF
--- a/task_cascadence/api/__init__.py
+++ b/task_cascadence/api/__init__.py
@@ -352,8 +352,6 @@ def pipeline_status(
     name: str,
     user_id: str = Depends(get_user_id),
     group_id: str = Depends(get_group_id),
-    _user_id: str = Depends(get_user_id),
-    _group_id: str = Depends(get_group_id),
 ):
     """Return stored pipeline stage events for ``name``."""
     store = StageStore()
@@ -371,8 +369,6 @@ def pipeline_audit(
     group_filter: str | None = Query(default=None, alias="group_id"),
     user_id: str = Depends(get_user_id),
     group_id: str = Depends(get_group_id),
-    _user_id: str = Depends(get_user_id),
-    _caller_group_id: str = Depends(get_group_id),
 ):
     """Return stored audit events for ``name`` filtered by the optional criteria."""
 

--- a/tests/test_api_pipeline.py
+++ b/tests/test_api_pipeline.py
@@ -242,6 +242,21 @@ def test_api_pipeline_audit(monkeypatch, tmp_path, auth_headers):
     assert resp.status_code == 400
 
 
+def test_pipeline_endpoints_openapi_headers_are_not_duplicated():
+    client = TestClient(app)
+    schema = client.get("/openapi.json").json()
+
+    status_parameters = schema["paths"]["/pipeline/{name}"]["get"]["parameters"]
+    status_headers = [param["name"] for param in status_parameters if param["in"] == "header"]
+    assert status_headers.count("x-user-id") == 1
+    assert status_headers.count("x-group-id") == 1
+
+    audit_parameters = schema["paths"]["/pipeline/{name}/audit"]["get"]["parameters"]
+    audit_headers = [param["name"] for param in audit_parameters if param["in"] == "header"]
+    assert audit_headers.count("x-user-id") == 1
+    assert audit_headers.count("x-group-id") == 1
+
+
 class ContextSignalTask(ExampleTask):
     name = "contextsignal"
 


### PR DESCRIPTION
### Motivation
- Clean up duplicate FastAPI `Depends` parameters on the pipeline endpoints which caused duplicated header entries in the generated OpenAPI schema.
- Keep exactly one scoped user/group dependency per endpoint while preserving the existing authorization checks in the audit endpoint.

### Description
- Removed duplicate `Depends(get_user_id)` and `Depends(get_group_id)` parameters from `pipeline_status` in `task_cascadence/api/__init__.py` so each endpoint now has a single scoped user and group dependency.
- Removed duplicate `Depends(get_user_id)` and `Depends(get_group_id)` parameters from `pipeline_audit` in `task_cascadence/api/__init__.py` and preserved existing scoped hash comparison and `HTTPException(403)` checks.
- Added a regression test `test_pipeline_endpoints_openapi_headers_are_not_duplicated` in `tests/test_api_pipeline.py` that asserts the OpenAPI schema for `/pipeline/{name}` and `/pipeline/{name}/audit` contains exactly one `x-user-id` and one `x-group-id` header parameter.

### Testing
- Ran `ruff check task_cascadence/api/__init__.py tests/test_api_pipeline.py` which passed.
- Executed `pytest -q tests/test_api_pipeline.py` (installed `pytest-cov` to satisfy test config) and the test file passed (`10 passed`).
- Verified the OpenAPI JSON via the added test to confirm the header parameters are no longer duplicated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15c6dc54832680c380166551e4cb)